### PR TITLE
Ability to override the default context constructor argument.

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -10,6 +10,7 @@
     DbContextInterfaceBaseClasses = "System.IDisposable";    // Specify what the base classes are for your database context interface
     DbContextBaseClass = "System.Data.Entity.DbContext";   // Specify what the base class is for your DbContext. For ASP.NET Identity use "IdentityDbContext<ApplicationUser>"
     ConnectionStringName = "MyDbContext";   // Searches for this connection string in config files listed below
+    //DefaultConstructorArgument = "EnvironmentConnectionStrings.MyDbContext"; //defaults to "Name=" + ConnectionStringName
     TargetFrameworkVersion = "4.51"; // Please set this to your .NET framework version, 4.0, 4.5, 4.51, etc.
     ConfigurationClassName = "Configuration"; // Configuration, Mapping, Map, etc. This is appended to the Poco class name to configure the mappings.
     ConfigFilenameSearchOrder = new[] { "app.config", "web.config", "app.config.transform", "web.config.transform" }; // Add more here if required. The config files are searched for in the local project first, then the whole solution second.

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -41,6 +41,8 @@
         string DbContextName = "MyDbContext";
         string DbContextInterfaceBaseClasses = "System.IDisposable";
         string DbContextBaseClass = "DbContext";
+        string _defaultConstructorArgument = null;
+        string DefaultConstructorArgument {get {return _defaultConstructorArgument ?? String.Format('"' + "Name={0}" + '"',ConnectionStringName);} set {_defaultConstructorArgument = value;}}
         string ConfigurationClassName = "Configuration";
         string CollectionType = "System.Collections.Generic.List";
         bool MakeClassesPartial = true;

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -193,7 +193,7 @@ foreach(Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey
         }
 
         public <#=DbContextName#>()
-            : base("Name=<#=ConnectionStringName#>")
+            : base(<#=DefaultConstructorArgument#>)
         {
 <#if(MakeClassesPartial) {#>            InitializePartial();
 <#}#>


### PR DESCRIPTION
We pull connection strings from the environment and initialize with a static helper class
