### PR TITLE
Fix FakeDbContext not implemnted with AdditionalContextInterfaceItems

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -487,6 +487,14 @@ foreach (Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKe
             InitializePartial();
 <#}#>        }
 
+<#foreach (string s in AdditionalContextInterfaceItems.Where(x => !string.IsNullOrEmpty(x)))
+{ #>
+		public <#=s.TrimEnd(';') #>
+        {
+            throw new System.NotImplementedException();
+        }
+<# } #>
+
         public int SaveChangesCount { get; private set; }
         public int SaveChanges()
         {


### PR DESCRIPTION
When Set the AdditionalContextInterfaceItems options, if AddUnitTestingDbContext option is true,
it's will compile error.
Beacause the FakeDbContext not implemented the AdditionalContextInterfaceItems options.
