### PR TITLE
Remove unicode prefix from unicode column default values.

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -846,6 +846,10 @@
                     Default = Default.Substring(1, Default.Length - 2);
                 }
 
+                // Remove unicode prefix
+                if (IsUnicode && Default.StartsWith("N"))
+                    Default = Default.Substring(1, Default.Length - 1);
+
                 if(Default.First() == '\'' && Default.Last() == '\'' && Default.Length >= 2)
                     Default = string.Format("\"{0}\"", Default.Substring(1, Default.Length - 2));
 


### PR DESCRIPTION
When adding a default value to an nvarchar column, the value is stored as N'value'.
I have removed the N so that the rest of the default cleanup works correctly.
