### PR TITLE
Proposed fix for Issue #96

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -477,7 +477,7 @@ foreach(var usingStatement in usingsContext.Distinct().OrderBy(x => x)) { #>
 
 <# } #>
     <#= CodeGeneratedAttribute #>
-    public <# if(MakeClassesPartial) { #>partial <# } #>class Fake<#=DbContextName #> : I<#=DbContextInterfaceName #>
+    public <# if(MakeClassesPartial) { #>partial <# } #>class Fake<#=DbContextName #> : <#=DbContextInterfaceName #>
     {
 <#
 foreach (Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase) select t)

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -477,7 +477,7 @@ foreach(var usingStatement in usingsContext.Distinct().OrderBy(x => x)) { #>
 
 <# } #>
     <#= CodeGeneratedAttribute #>
-    public <# if(MakeClassesPartial) { #>partial <# } #>class Fake<#=DbContextName #> : I<#=DbContextName #>
+    public <# if(MakeClassesPartial) { #>partial <# } #>class Fake<#=DbContextName #> : I<#=DbContextInterfaceName #>
     {
 <#
 foreach (Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase) select t)


### PR DESCRIPTION
This fixes Issue #96. Instead of dynamically building the Interface Name by an assumed concatenation of "I" and the DbContextName, this instead uses the DbContextInterfaceName variable which should have already been built whether via custom means or dynamically based on DbContextName if the user does not set it.
