### PR TITLE
Small improvements

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -352,14 +352,22 @@
 
     // Apply totally custom renaming rule after performing `ForeignKeyName` defined above.
     // It can be useful in applying pluralization.
-    /*ForeignKeyRename = (tableName, name) =>
+    /*ForeignKeyRename = (tableName, foreignKey, name) =>
     {
-        if (tableName == "Employee" && name == "Employee_ReportsTo")
+        if (tableName == "Employee" && foreignKey.FkColumn == "ReportsTo")
             return "Manager";
+
+        if (tableName == "Territories" && foreignKey.FkTableName == "EmployeeTerritories")
+            return "Locations";
+
+        if (tableName == "Employee" && foreignKey.FkTableName == "Orders" && foreignKey.FkColumn == "EmployeeID")
+        {
+            return "ContactPerson";
+        }
 
         return name;
     };*/
-    ForeignKeyRename = (tableName, foreignKeyName) => foreignKeyName;
+    ForeignKeyRename = (tableName, foreignKey, foreignKeyName) => foreignKeyName;
 
     // Return true to include this table in the db context
     ConfigurationFilter = (Table t) =>

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -1,4 +1,5 @@
 ﻿<#@ include file="EF.Reverse.POCO.Core.ttinclude" #>
+<#@ include file="EF.Reverse.POCO.Pluralization.ttinclude" #>
 <#
     // v2.24.0
     // Please make changes to the settings below.
@@ -76,7 +77,23 @@
     //    new CustomPluralizationEntry("Course", "Courses"),
     //    new CustomPluralizationEntry("Status", "Status") // Use same value to prevent pluralisation
     //});
+    /*
+    Inflector.PluralizationService = new TransformationPluralizationService(
+        name =>
+        {
+            if (name.EndsWith("Set"))
+                return name.Substring(0, name.Length - 3) + "Qry";
 
+            return null;
+        },
+        name =>
+        {
+            if (name.EndsWith("Qry"))
+                return name.Substring(0, name.Length - 3) + "Set";
+
+            return null;
+        });
+    */
 
     // Elements to generate ***************************************************************************************************************
     // Add the elements that should be generated when the template is executed.
@@ -218,6 +235,7 @@
             name = name.Remove(0, 3);
         return name.Replace("my_sp_", "");
     };*/
+    //StoredProcedureRename = (name, schema) => name == "SalesByCategory" ? "SalesByCategoryProc" : name;
     StoredProcedureRename = (name, schema) => name;   // Do nothing by default
 
     // Use the following function to rename the return model automatically generated for stored procedure.

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -297,7 +297,7 @@
 
     ForeignKeyName = (tableName, foreignKeyName, attempt) =>
     {
-        // 5 Attempts to correctly name the foreign key
+        // 6 Attempts to correctly name the foreign key
         switch (attempt)
         {
             case 1:
@@ -310,14 +310,19 @@
                 return foreignKeyName.Remove(foreignKeyName.Length-2, 2);
 
             case 3:
+                // Only called if foreign key name starts with "id"
+                // Use foreign key name without "id" at end of string
+                return foreignKeyName.Substring(2);
+
+            case 4:
                 // Use foreign key name only
                 return foreignKeyName;
 
-            case 4:
+            case 5:
                 // Use table name and foreign key name
                 return tableName + "_" + foreignKeyName;
 
-            case 5:
+            case 6:
                 // Used in for loop 1 to 99 to append a number to the end
                 return tableName;
 

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -220,6 +220,20 @@
     };*/
     StoredProcedureRename = (name, schema) => name;   // Do nothing by default
 
+    // Use the following function to rename the return model automatically generated for stored procedure.
+    // By default it's <proc_name>ReturnModel.
+    // Example:
+    /*StoredProcedureReturnModelRename = (name, sp) =>
+    {
+        if (sp.NameHumanCase.Equals("ComputeValuesForDate", StringComparison.InvariantCultureIgnoreCase))
+            return "ValueSet";
+        if (sp.NameHumanCase.Equals("SalesByYear", StringComparison.InvariantCultureIgnoreCase))
+            return "SalesSet";
+
+        return name;
+    };*/
+    StoredProcedureReturnModelRename = (name, sp) => name; // Do nothing by default
+
     // StoredProcedure return types *******************************************************************************************************
     // Override generation of return models for stored procedures that return entities.
     // If a stored procedure returns an entity, add it to the list below.

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -332,6 +332,17 @@
         }
     };
 
+    // Apply totally custom renaming rule after performing `ForeignKeyName` defined above.
+    // It can be useful in applying pluralization.
+    /*ForeignKeyRename = (tableName, name) =>
+    {
+        if (tableName == "Employee" && name == "Employee_ReportsTo")
+            return "Manager";
+
+        return name;
+    };*/
+    ForeignKeyRename = (tableName, foreignKeyName) => foreignKeyName;
+
     // Return true to include this table in the db context
     ConfigurationFilter = (Table t) =>
     {

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -84,6 +84,7 @@
         private string _configFilePath = "";
         Func<string, string, string> TableRename;
         Func<string, string, string> StoredProcedureRename;
+        static Func<string, StoredProcedure, string> StoredProcedureReturnModelRename;
         Func<Column, Table, Column> UpdateColumn;
         Func<ForeignKey, ForeignKey> ForeignKeyFilter;
         Func<string, string, short, string> ForeignKeyName;
@@ -3218,11 +3219,22 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
         };
 
         public static readonly Func<StoredProcedure, string> WriteStoredProcReturnModelName = sp =>
-            StoredProcedureReturnTypes.ContainsKey(sp.NameHumanCase)
-                ? StoredProcedureReturnTypes[sp.NameHumanCase]
-                : StoredProcedureReturnTypes.ContainsKey(sp.Name)
-                    ? StoredProcedureReturnTypes[sp.Name]
-                    : string.Format("{0}ReturnModel", sp.NameHumanCase);
+        {
+            if (StoredProcedureReturnTypes.ContainsKey(sp.NameHumanCase))
+                return StoredProcedureReturnTypes[sp.NameHumanCase];
+            if (StoredProcedureReturnTypes.ContainsKey(sp.Name))
+                return StoredProcedureReturnTypes[sp.Name];
+
+            var name = string.Format("{0}ReturnModel", sp.NameHumanCase);
+            if (StoredProcedureReturnModelRename != null)
+            {
+                var customName = StoredProcedureReturnModelRename(name, sp);
+                if (!string.IsNullOrEmpty(customName))
+                    name = customName;
+            }
+
+            return name;
+        };
 
         public static readonly Func<DataColumn, string> WriteStoredProcReturnColumn = col =>
             string.Format("public {0} {1} {{ get; set; }}",

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -2892,7 +2892,23 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 3
-                col = ForeignKeyName(tableNameHumanCase, fkName, 3);
+                if (fkName.ToLowerInvariant().StartsWith("id"))
+                {
+                    col = ForeignKeyName(tableNameHumanCase, fkName, 3);
+                    if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
+                        !ReverseNavigationUniquePropNameClashes.Contains(col))
+                        ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
+
+                    if (!ReverseNavigationUniquePropNameClashes.Contains(col) &&
+                        !ReverseNavigationUniquePropName.Contains(col))
+                    {
+                        ReverseNavigationUniquePropName.Add(col);
+                        return col;
+                    }
+                }
+
+                // Attempt 4
+                col = ForeignKeyName(tableNameHumanCase, fkName, 4);
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                     !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2904,8 +2920,8 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     return col;
                 }
 
-                // Attempt 4
-                col = ForeignKeyName(tableNameHumanCase, fkName, 4);
+                // Attempt 5
+                col = ForeignKeyName(tableNameHumanCase, fkName, 5);
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) && !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
 
@@ -2915,10 +2931,10 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     return col;
                 }
 
-                // Attempt 5
+                // Attempt 6
                 for (int n = 1; n < 99; ++n)
                 {
-                    col = ForeignKeyName(tableNameHumanCase, fkName, 5) + n;
+                    col = ForeignKeyName(tableNameHumanCase, fkName, 6) + n;
 
                     if (ReverseNavigationUniquePropName.Contains(col))
                         continue;
@@ -2928,7 +2944,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Give up
-                return ForeignKeyName(tableNameHumanCase, fkName, 6);
+                return ForeignKeyName(tableNameHumanCase, fkName, 7);
             }
 
             public void AddReverseNavigation(Relationship relationship, string fkName, Table fkTable, string propName, string constraint, string collectionType, CommentsStyle includeComments)

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -88,7 +88,7 @@
         Func<Column, Table, Column> UpdateColumn;
         Func<ForeignKey, ForeignKey> ForeignKeyFilter;
         Func<string, string, short, string> ForeignKeyName;
-        static Func<string, string, string> ForeignKeyRename;
+        static Func<string, ForeignKey, string, string> ForeignKeyRename;
         string MigrationConfigurationFileName = null;
         string MigrationStrategy = "MigrateDatabaseToLatestVersion";
         string ContextKey = null;
@@ -2852,9 +2852,9 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 return Columns.SingleOrDefault(x => String.Compare(x.Name, columnName, StringComparison.OrdinalIgnoreCase) == 0);
             }
 
-            public string GetForeignKeyRenamed(string tableNameHumanCase, string fkName)
+            public string GetForeignKeyRenamed(string tableNameHumanCase, ForeignKey foreignKey, string fkName)
             {
-                return ForeignKeyRename != null ? ForeignKeyRename(tableNameHumanCase, fkName) : fkName;
+                return ForeignKeyRename != null ? ForeignKeyRename(tableNameHumanCase, foreignKey, fkName) : fkName;
             }
 
             public string GetUniqueColumnName(string tableNameHumanCase, ForeignKey foreignKey, bool useCamelCase, bool checkForFkNameClashes, bool makeSingular, Func<string, string, short, string> ForeignKeyName)
@@ -2873,7 +2873,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
 
                 // Attempt 1
                 string fkName = (useCamelCase ? Inflector.ToTitleCase(foreignKey.FkColumn) : foreignKey.FkColumn).Replace(" ", "").Replace("$", "");
-                string name = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 1));
+                string name = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 1));
                 string col;
                 if (!ReverseNavigationUniquePropNameClashes.Contains(name) && !ReverseNavigationUniquePropName.Contains(name))
                 {
@@ -2884,7 +2884,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 2
                 if (fkName.ToLowerInvariant().EndsWith("id"))
                 {
-                    col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 2));
+                    col = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 2));
                     if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                         !ReverseNavigationUniquePropNameClashes.Contains(col))
                         ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2900,7 +2900,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 3
                 if (fkName.ToLowerInvariant().StartsWith("id"))
                 {
-                    col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 3));
+                    col = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 3));
                     if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                         !ReverseNavigationUniquePropNameClashes.Contains(col))
                         ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2914,7 +2914,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 4
-                col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 4));
+                col = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 4));
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                     !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2927,7 +2927,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 5
-                col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 5));
+                col = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 5));
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) && !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
 
@@ -2940,7 +2940,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 6
                 for (int n = 1; n < 99; ++n)
                 {
-                    col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 6) + n);
+                    col = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 6) + n);
 
                     if (ReverseNavigationUniquePropName.Contains(col))
                         continue;
@@ -2950,7 +2950,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Give up
-                return GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 7));
+                return GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 7));
             }
 
             public void AddReverseNavigation(Relationship relationship, string fkName, Table fkTable, string propName, string constraint, string collectionType, CommentsStyle includeComments)

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -88,6 +88,7 @@
         Func<Column, Table, Column> UpdateColumn;
         Func<ForeignKey, ForeignKey> ForeignKeyFilter;
         Func<string, string, short, string> ForeignKeyName;
+        static Func<string, string, string> ForeignKeyRename;
         string MigrationConfigurationFileName = null;
         string MigrationStrategy = "MigrateDatabaseToLatestVersion";
         string ContextKey = null;
@@ -2851,6 +2852,11 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 return Columns.SingleOrDefault(x => String.Compare(x.Name, columnName, StringComparison.OrdinalIgnoreCase) == 0);
             }
 
+            public string GetForeignKeyRenamed(string tableNameHumanCase, string fkName)
+            {
+                return ForeignKeyRename != null ? ForeignKeyRename(tableNameHumanCase, fkName) : fkName;
+            }
+
             public string GetUniqueColumnName(string tableNameHumanCase, ForeignKey foreignKey, bool useCamelCase, bool checkForFkNameClashes, bool makeSingular, Func<string, string, short, string> ForeignKeyName)
             {
                 if (ReverseNavigationUniquePropName.Count == 0)
@@ -2867,7 +2873,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
 
                 // Attempt 1
                 string fkName = (useCamelCase ? Inflector.ToTitleCase(foreignKey.FkColumn) : foreignKey.FkColumn).Replace(" ", "").Replace("$", "");
-                string name = ForeignKeyName(tableNameHumanCase, fkName, 1);
+                string name = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 1));
                 string col;
                 if (!ReverseNavigationUniquePropNameClashes.Contains(name) && !ReverseNavigationUniquePropName.Contains(name))
                 {
@@ -2878,7 +2884,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 2
                 if (fkName.ToLowerInvariant().EndsWith("id"))
                 {
-                    col = ForeignKeyName(tableNameHumanCase, fkName, 2);
+                    col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 2));
                     if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                         !ReverseNavigationUniquePropNameClashes.Contains(col))
                         ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2894,7 +2900,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 3
                 if (fkName.ToLowerInvariant().StartsWith("id"))
                 {
-                    col = ForeignKeyName(tableNameHumanCase, fkName, 3);
+                    col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 3));
                     if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                         !ReverseNavigationUniquePropNameClashes.Contains(col))
                         ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2908,7 +2914,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 4
-                col = ForeignKeyName(tableNameHumanCase, fkName, 4);
+                col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 4));
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                     !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2921,7 +2927,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 5
-                col = ForeignKeyName(tableNameHumanCase, fkName, 5);
+                col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 5));
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) && !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
 
@@ -2934,7 +2940,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 6
                 for (int n = 1; n < 99; ++n)
                 {
-                    col = ForeignKeyName(tableNameHumanCase, fkName, 6) + n;
+                    col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 6) + n);
 
                     if (ReverseNavigationUniquePropName.Contains(col))
                         continue;
@@ -2944,7 +2950,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Give up
-                return ForeignKeyName(tableNameHumanCase, fkName, 7);
+                return GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 7));
             }
 
             public void AddReverseNavigation(Relationship relationship, string fkName, Table fkTable, string propName, string constraint, string collectionType, CommentsStyle includeComments)

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Pluralization.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Pluralization.ttinclude
@@ -1,0 +1,171 @@
+<#@ template debug="true" hostspecific="true" language="C#" #>
+<#@ import namespace="System.Data.Entity.Infrastructure.Pluralization" #>
+
+<#+
+
+public sealed class DictionaryPluralizationService : IPluralizationService
+{
+    private readonly Dictionary<string, CustomPluralizationEntry> _userDictionarySingular;
+    private readonly Dictionary<string, CustomPluralizationEntry> _userDictionaryPlural;
+
+    public DictionaryPluralizationService(IEnumerable<CustomPluralizationEntry> userEntries)
+    {
+        _userDictionarySingular = new Dictionary<string, CustomPluralizationEntry>();
+        _userDictionaryPlural = new Dictionary<string, CustomPluralizationEntry>();
+
+        if (userEntries != null)
+        {
+            foreach (var entry in userEntries)
+            {
+                _userDictionarySingular[entry.Singular] = entry;
+                _userDictionaryPlural[entry.Plural] = entry;
+            }
+        }
+    }
+
+    public string Pluralize(string word)
+    {
+        CustomPluralizationEntry result;
+
+        if (_userDictionarySingular.TryGetValue(word, out result))
+        {
+            return result.Plural;
+        }
+
+        return word;
+    }
+
+    public string Singularize(string word)
+    {
+        CustomPluralizationEntry result;
+
+        if (_userDictionaryPlural.TryGetValue(word, out result))
+        {
+            return result.Singular;
+        }
+
+        return word;
+    }
+}
+
+public sealed class TransformationPluralizationService : IPluralizationService
+{
+    private readonly Func<string, string> _toSingular;
+    private readonly Func<string, string> _toPlural;
+
+    public TransformationPluralizationService(Func<string, string> toPlural, Func<string, string> toSingular)
+    {
+        _toSingular = toSingular;
+        _toPlural = toPlural;
+    }
+
+    public TransformationPluralizationService(Func<string, string> toPlural)
+    {
+        _toPlural = toPlural;
+    }
+
+    public string Pluralize(string word)
+    {
+        if (_toPlural != null)
+        {
+            var result = _toPlural(word);
+            if (result != null)
+                return result;
+        }
+
+        return word;
+    }
+
+    public string Singularize(string word)
+    {
+        if (_toSingular != null)
+        {
+            var result = _toSingular(word);
+            if (result != null)
+                return result;
+        }
+
+        return word;
+    }
+}
+
+public class CombinedPluralizationService : IPluralizationService
+{
+    private readonly Dictionary<string, CustomPluralizationEntry> _userDictionarySingular;
+    private readonly Dictionary<string, CustomPluralizationEntry> _userDictionaryPlural;
+    private Func<string, string> _toPlural;
+    private Func<string, string> _toSingular;
+
+    public CombinedPluralizationService(IEnumerable<CustomPluralizationEntry> userEntries, Func<string, string> toPlural, Func<string, string> toSingular)
+    {
+        _userDictionarySingular = new Dictionary<string, CustomPluralizationEntry>();
+        _userDictionaryPlural = new Dictionary<string, CustomPluralizationEntry>();
+
+        Add(userEntries);
+        SetTransform(toPlural, toSingular);
+    }
+
+    public CombinedPluralizationService()
+    {
+        _userDictionarySingular = new Dictionary<string, CustomPluralizationEntry>();
+        _userDictionaryPlural = new Dictionary<string, CustomPluralizationEntry>();
+    }
+
+    protected void Add(IEnumerable<CustomPluralizationEntry> userEntries)
+    {
+        if (userEntries != null)
+        {
+            foreach (var entry in userEntries)
+            {
+                _userDictionarySingular[entry.Singular] = entry;
+                _userDictionaryPlural[entry.Plural] = entry;
+            }
+        }
+    }
+
+    protected void SetTransform(Func<string, string> toPlural, Func<string, string> toSingular)
+    {
+        _toPlural = toPlural;
+        _toSingular = toSingular;
+    }
+
+    public string Pluralize(string word)
+    {
+        CustomPluralizationEntry result;
+
+        if (_userDictionarySingular.TryGetValue(word, out result))
+        {
+            return result.Plural;
+        }
+
+        if (_toPlural != null)
+        {
+            var converted = _toPlural(word);
+            if (converted != null)
+                return converted;
+        }
+
+        return word;
+    }
+
+    public string Singularize(string word)
+    {
+        CustomPluralizationEntry result;
+
+        if (_userDictionaryPlural.TryGetValue(word, out result))
+        {
+            return result.Singular;
+        }
+
+        if (_toSingular != null)
+        {
+            var converted = _toSingular(word);
+            if (converted != null)
+                return converted;
+        }
+
+        return word;
+    }
+}
+
+#>

--- a/EntityFramework.Reverse.POCO.Generator/EntityFramework.Reverse.POCO.Generator.csproj
+++ b/EntityFramework.Reverse.POCO.Generator/EntityFramework.Reverse.POCO.Generator.csproj
@@ -81,6 +81,7 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Database NorthwindSqlCe40.cs</LastGenOutput>
     </None>
+    <None Include="EF.Reverse.POCO.Pluralization.ttinclude" />
     <None Include="EF.Reverse.POCO.Generator.pfx" />
     <None Include="App.config">
       <SubType>Designer</SubType>


### PR DESCRIPTION
I applied functionalities used in my company's projects:
- allow renaming of model classes returned by stored-procedures
- another attempt for naming foreign-key to look for "id" at the beginning (breaking change, as it shifted numbering of some further attempts)
- allow renaming of foreign-key names after applying "attempts approach"
- added base classes for custom pluralization services
