### PR TITLE
Added option to rename procs return models

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -220,6 +220,20 @@
     };*/
     StoredProcedureRename = (name, schema) => name;   // Do nothing by default
 
+    // Use the following function to rename the return model automatically generated for stored procedure.
+    // By default it's <proc_name>ReturnModel.
+    // Example:
+    /*StoredProcedureReturnModelRename = (name, sp) =>
+    {
+        if (sp.NameHumanCase.Equals("ComputeValuesForDate", StringComparison.InvariantCultureIgnoreCase))
+            return "ValueSet";
+        if (sp.NameHumanCase.Equals("SalesByYear", StringComparison.InvariantCultureIgnoreCase))
+            return "SalesSet";
+
+        return name;
+    };*/
+    StoredProcedureReturnModelRename = (name, sp) => name; // Do nothing by default
+
     // StoredProcedure return types *******************************************************************************************************
     // Override generation of return models for stored procedures that return entities.
     // If a stored procedure returns an entity, add it to the list below.

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -84,6 +84,7 @@
         private string _configFilePath = "";
         Func<string, string, string> TableRename;
         Func<string, string, string> StoredProcedureRename;
+        static Func<string, StoredProcedure, string> StoredProcedureReturnModelRename;
         Func<Column, Table, Column> UpdateColumn;
         Func<ForeignKey, ForeignKey> ForeignKeyFilter;
         Func<string, string, short, string> ForeignKeyName;
@@ -3218,11 +3219,22 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
         };
 
         public static readonly Func<StoredProcedure, string> WriteStoredProcReturnModelName = sp =>
-            StoredProcedureReturnTypes.ContainsKey(sp.NameHumanCase)
-                ? StoredProcedureReturnTypes[sp.NameHumanCase]
-                : StoredProcedureReturnTypes.ContainsKey(sp.Name)
-                    ? StoredProcedureReturnTypes[sp.Name]
-                    : string.Format("{0}ReturnModel", sp.NameHumanCase);
+        {
+            if (StoredProcedureReturnTypes.ContainsKey(sp.NameHumanCase))
+                return StoredProcedureReturnTypes[sp.NameHumanCase];
+            if (StoredProcedureReturnTypes.ContainsKey(sp.Name))
+                return StoredProcedureReturnTypes[sp.Name];
+
+            var name = string.Format("{0}ReturnModel", sp.NameHumanCase);
+            if (StoredProcedureReturnModelRename != null)
+            {
+                var customName = StoredProcedureReturnModelRename(name, sp);
+                if (!string.IsNullOrEmpty(customName))
+                    name = customName;
+            }
+
+            return name;
+        };
 
         public static readonly Func<DataColumn, string> WriteStoredProcReturnColumn = col =>
             string.Format("public {0} {1} {{ get; set; }}",


### PR DESCRIPTION
No more forced to use `<proc_name>ReturnModel` name only, while those
models remain automatically generated.
