### PR TITLE
Foreign key renaming check 'id' at name start

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -283,7 +283,7 @@
 
     ForeignKeyName = (tableName, foreignKeyName, attempt) =>
     {
-        // 5 Attempts to correctly name the foreign key
+        // 6 Attempts to correctly name the foreign key
         switch (attempt)
         {
             case 1:
@@ -296,14 +296,19 @@
                 return foreignKeyName.Remove(foreignKeyName.Length-2, 2);
 
             case 3:
+                // Only called if foreign key name starts with "id"
+                // Use foreign key name without "id" at end of string
+                return foreignKeyName.Substring(2);
+
+            case 4:
                 // Use foreign key name only
                 return foreignKeyName;
 
-            case 4:
+            case 5:
                 // Use table name and foreign key name
                 return tableName + "_" + foreignKeyName;
 
-            case 5:
+            case 6:
                 // Used in for loop 1 to 99 to append a number to the end
                 return tableName;
 

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -2891,7 +2891,23 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 3
-                col = ForeignKeyName(tableNameHumanCase, fkName, 3);
+                if (fkName.ToLowerInvariant().StartsWith("id"))
+                {
+                    col = ForeignKeyName(tableNameHumanCase, fkName, 3);
+                    if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
+                        !ReverseNavigationUniquePropNameClashes.Contains(col))
+                        ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
+
+                    if (!ReverseNavigationUniquePropNameClashes.Contains(col) &&
+                        !ReverseNavigationUniquePropName.Contains(col))
+                    {
+                        ReverseNavigationUniquePropName.Add(col);
+                        return col;
+                    }
+                }
+
+                // Attempt 4
+                col = ForeignKeyName(tableNameHumanCase, fkName, 4);
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                     !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2903,8 +2919,8 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     return col;
                 }
 
-                // Attempt 4
-                col = ForeignKeyName(tableNameHumanCase, fkName, 4);
+                // Attempt 5
+                col = ForeignKeyName(tableNameHumanCase, fkName, 5);
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) && !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
 
@@ -2914,10 +2930,10 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     return col;
                 }
 
-                // Attempt 5
+                // Attempt 6
                 for (int n = 1; n < 99; ++n)
                 {
-                    col = ForeignKeyName(tableNameHumanCase, fkName, 5) + n;
+                    col = ForeignKeyName(tableNameHumanCase, fkName, 6) + n;
 
                     if (ReverseNavigationUniquePropName.Contains(col))
                         continue;
@@ -2927,7 +2943,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Give up
-                return ForeignKeyName(tableNameHumanCase, fkName, 6);
+                return ForeignKeyName(tableNameHumanCase, fkName, 7);
             }
 
             public void AddReverseNavigation(Relationship relationship, string fkName, Table fkTable, string propName, string constraint, string collectionType, CommentsStyle includeComments)


### PR DESCRIPTION
It's a breaking change as it shifted some of the other attempts to keep it next to other 'id' detection attempt.
