### PR TITLE
Foreign key rename

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -315,14 +315,22 @@
 
     // Apply totally custom renaming rule after performing `ForeignKeyName` defined above.
     // It can be useful in applying pluralization.
-    /*ForeignKeyRename = (tableName, name) =>
+    /*ForeignKeyRename = (tableName, foreignKey, name) =>
     {
-        if (tableName == "Employee" && name == "Employee_ReportsTo")
+        if (tableName == "Employee" && foreignKey.FkColumn == "ReportsTo")
             return "Manager";
+
+        if (tableName == "Territories" && foreignKey.FkTableName == "EmployeeTerritories")
+            return "Locations";
+
+        if (tableName == "Employee" && foreignKey.FkTableName == "Orders" && foreignKey.FkColumn == "EmployeeID")
+        {
+            return "ContactPerson";
+        }
 
         return name;
     };*/
-    ForeignKeyRename = (tableName, foreignKeyName) => foreignKeyName;
+    ForeignKeyRename = (tableName, foreignKey, foreignKeyName) => foreignKeyName;
 
     // Return true to include this table in the db context
     ConfigurationFilter = (Table t) =>

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -313,6 +313,17 @@
         }
     };
 
+    // Apply totally custom renaming rule after performing `ForeignKeyName` defined above.
+    // It can be useful in applying pluralization.
+    /*ForeignKeyRename = (tableName, name) =>
+    {
+        if (tableName == "Employee" && name == "Employee_ReportsTo")
+            return "Manager";
+
+        return name;
+    };*/
+    ForeignKeyRename = (tableName, foreignKeyName) => foreignKeyName;
+
     // Return true to include this table in the db context
     ConfigurationFilter = (Table t) =>
     {

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -87,7 +87,7 @@
         Func<Column, Table, Column> UpdateColumn;
         Func<ForeignKey, ForeignKey> ForeignKeyFilter;
         Func<string, string, short, string> ForeignKeyName;
-        static Func<string, string, string> ForeignKeyRename;
+        static Func<string, ForeignKey, string, string> ForeignKeyRename;
         string MigrationConfigurationFileName = null;
         string MigrationStrategy = "MigrateDatabaseToLatestVersion";
         string ContextKey = null;
@@ -2851,9 +2851,9 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 return Columns.SingleOrDefault(x => String.Compare(x.Name, columnName, StringComparison.OrdinalIgnoreCase) == 0);
             }
 
-            public string GetForeignKeyRenamed(string tableNameHumanCase, string fkName)
+            public string GetForeignKeyRenamed(string tableNameHumanCase, ForeignKey foreignKey, string fkName)
             {
-                return ForeignKeyRename != null ? ForeignKeyRename(tableNameHumanCase, fkName) : fkName;
+                return ForeignKeyRename != null ? ForeignKeyRename(tableNameHumanCase, foreignKey, fkName) : fkName;
             }
 
             public string GetUniqueColumnName(string tableNameHumanCase, ForeignKey foreignKey, bool useCamelCase, bool checkForFkNameClashes, bool makeSingular, Func<string, string, short, string> ForeignKeyName)
@@ -2872,7 +2872,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
 
                 // Attempt 1
                 string fkName = (useCamelCase ? Inflector.ToTitleCase(foreignKey.FkColumn) : foreignKey.FkColumn).Replace(" ", "").Replace("$", "");
-                string name = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 1));
+                string name = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 1));
                 string col;
                 if (!ReverseNavigationUniquePropNameClashes.Contains(name) && !ReverseNavigationUniquePropName.Contains(name))
                 {
@@ -2883,7 +2883,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 2
                 if (fkName.ToLowerInvariant().EndsWith("id"))
                 {
-                    col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 2));
+                    col = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 2));
                     if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                         !ReverseNavigationUniquePropNameClashes.Contains(col))
                         ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2897,7 +2897,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 3
-                col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 3));
+                col = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 3));
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                     !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2910,7 +2910,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 4
-                col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 4));
+                col = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 4));
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) && !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
 
@@ -2923,7 +2923,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 5
                 for (int n = 1; n < 99; ++n)
                 {
-                    col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 5) + n);
+                    col = GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 5) + n);
 
                     if (ReverseNavigationUniquePropName.Contains(col))
                         continue;
@@ -2933,7 +2933,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Give up
-                return GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 6));
+                return GetForeignKeyRenamed(tableNameHumanCase, foreignKey, ForeignKeyName(tableNameHumanCase, fkName, 6));
             }
 
             public void AddReverseNavigation(Relationship relationship, string fkName, Table fkTable, string propName, string constraint, string collectionType, CommentsStyle includeComments)

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -87,6 +87,7 @@
         Func<Column, Table, Column> UpdateColumn;
         Func<ForeignKey, ForeignKey> ForeignKeyFilter;
         Func<string, string, short, string> ForeignKeyName;
+        static Func<string, string, string> ForeignKeyRename;
         string MigrationConfigurationFileName = null;
         string MigrationStrategy = "MigrateDatabaseToLatestVersion";
         string ContextKey = null;
@@ -2850,6 +2851,11 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 return Columns.SingleOrDefault(x => String.Compare(x.Name, columnName, StringComparison.OrdinalIgnoreCase) == 0);
             }
 
+            public string GetForeignKeyRenamed(string tableNameHumanCase, string fkName)
+            {
+                return ForeignKeyRename != null ? ForeignKeyRename(tableNameHumanCase, fkName) : fkName;
+            }
+
             public string GetUniqueColumnName(string tableNameHumanCase, ForeignKey foreignKey, bool useCamelCase, bool checkForFkNameClashes, bool makeSingular, Func<string, string, short, string> ForeignKeyName)
             {
                 if (ReverseNavigationUniquePropName.Count == 0)
@@ -2866,7 +2872,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
 
                 // Attempt 1
                 string fkName = (useCamelCase ? Inflector.ToTitleCase(foreignKey.FkColumn) : foreignKey.FkColumn).Replace(" ", "").Replace("$", "");
-                string name = ForeignKeyName(tableNameHumanCase, fkName, 1);
+                string name = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 1));
                 string col;
                 if (!ReverseNavigationUniquePropNameClashes.Contains(name) && !ReverseNavigationUniquePropName.Contains(name))
                 {
@@ -2877,7 +2883,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 2
                 if (fkName.ToLowerInvariant().EndsWith("id"))
                 {
-                    col = ForeignKeyName(tableNameHumanCase, fkName, 2);
+                    col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 2));
                     if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                         !ReverseNavigationUniquePropNameClashes.Contains(col))
                         ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2891,7 +2897,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 3
-                col = ForeignKeyName(tableNameHumanCase, fkName, 3);
+                col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 3));
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                     !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -2904,7 +2910,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 4
-                col = ForeignKeyName(tableNameHumanCase, fkName, 4);
+                col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 4));
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) && !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
 
@@ -2917,7 +2923,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 5
                 for (int n = 1; n < 99; ++n)
                 {
-                    col = ForeignKeyName(tableNameHumanCase, fkName, 5) + n;
+                    col = GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 5) + n);
 
                     if (ReverseNavigationUniquePropName.Contains(col))
                         continue;
@@ -2927,7 +2933,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Give up
-                return ForeignKeyName(tableNameHumanCase, fkName, 6);
+                return GetForeignKeyRenamed(tableNameHumanCase, ForeignKeyName(tableNameHumanCase, fkName, 6));
             }
 
             public void AddReverseNavigation(Relationship relationship, string fkName, Table fkTable, string propName, string constraint, string collectionType, CommentsStyle includeComments)


### PR DESCRIPTION
After the name of the foreign-key is calculated by attempted calls to `ForeignKeyName` I tried to inject a common way to customize it further for selected tables/classes. Thanks to new callback `ForeignKeyRename` those customizations can be kept in one place.
