### PR TITLE
Optionally exclude reverse navigation properties

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -274,10 +274,15 @@
 
     ForeignKeyFilter = (ForeignKey fk) =>
     {
-        // Return null to exclude this foreign key
+        // Return null to exclude this foreign key, or set IncludeReverseNavigationProperty = false
+        // to include the foeriegn key but not generate reverse navigation properties.
         // Example, to exclude all foreign keys for the Categories table, use:
         // if (fk.PkTableName == "Categories")
         //    return null;
+        // Example, to exclude reverse navigation properties for tables ending with Type, use:
+        // if (fk.PkTableName.EndsWith("Type"))
+        //    fk.IncludeReverseNavigationProperty = false;
+
         return fk;
     };
 

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -741,6 +741,7 @@
             public List<string> ConfigFk = new List<string>();
             public string Entity;
             public List<string> EntityFk = new List<string>();
+            public bool IncludeReverseNavigation;
 
             public Table ParentTable;
 
@@ -748,6 +749,7 @@
             {
                 ConfigFk = new List<string>();
                 EntityFk = new List<string>();
+                IncludeReverseNavigation = false;
             }
 
             private void SetupEntity(CommentsStyle includeComments, CommentsStyle includeExtendedPropertyComments, bool usePrivateSetterForComputedColumns)
@@ -2344,8 +2346,11 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         mapKey = string.Format("\"{0}\"", fkCol.col.Name);
                     }
 
-                    fkCol.col.ConfigFk.Add(string.Format("{0};{1}", GetRelationship(relationship, fkCol.col, pkCol, pkPropName, fkPropName, manyToManyMapping, mapKey, foreignKey.CascadeOnDelete), includeComments != CommentsStyle.None ? " // " + foreignKey.ConstraintName : string.Empty));
-                    pkTable.AddReverseNavigation(relationship, pkTableHumanCase, fkTable, fkPropName, string.Format("{0}.{1}", fkTable.Name, foreignKey.ConstraintName), collectionType, includeComments);
+                    fkCol.col.ConfigFk.Add(string.Format("{0};{1}", GetRelationship(relationship, fkCol.col, pkCol, pkPropName, fkPropName, manyToManyMapping, mapKey, foreignKey.CascadeOnDelete, foreignKey.IncludeReverseNavigationProperty), includeComments != CommentsStyle.None ? " // " + foreignKey.ConstraintName : string.Empty));
+                    if(foreignKey.IncludeReverseNavigationProperty)
+                    {
+                        pkTable.AddReverseNavigation(relationship, pkTableHumanCase, fkTable, fkPropName, string.Format("{0}.{1}", fkTable.Name, foreignKey.ConstraintName), collectionType, includeComments);
+                    }
                 }
             }
 
@@ -2373,12 +2378,12 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
             }
 
-            private static string GetRelationship(Relationship relationship, Column fkCol, Column pkCol, string pkPropName, string fkPropName, string manyToManyMapping, string mapKey, bool cascadeOnDelete)
+            private static string GetRelationship(Relationship relationship, Column fkCol, Column pkCol, string pkPropName, string fkPropName, string manyToManyMapping, string mapKey, bool cascadeOnDelete, bool hasReverseNavProp)
             {
                 return string.Format("Has{0}(a => a.{1}){2}{3}",
                     GetHasMethod(relationship, fkCol, pkCol),
                     pkPropName,
-                    GetWithMethod(relationship, fkCol, fkPropName, manyToManyMapping, mapKey),
+                    GetWithMethod(relationship, fkCol, fkPropName, manyToManyMapping, mapKey, hasReverseNavProp),
                     cascadeOnDelete ? string.Empty: ".WillCascadeOnDelete(false)");
             }
 
@@ -2407,23 +2412,24 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             // WithMany
             // WithRequiredPrincipal
             // WithRequiredDependent
-            private static string GetWithMethod(Relationship relationship, Column fkCol, string fkPropName, string manyToManyMapping, string mapKey)
+            private static string GetWithMethod(Relationship relationship, Column fkCol, string fkPropName, string manyToManyMapping, string mapKey, bool hasReverseNavProp)
             {
+                string withParam = hasReverseNavProp ? string.Format("b => b.{0}", fkPropName) : string.Empty;
                 switch (relationship)
                 {
                     case Relationship.OneToOne:
-                        return string.Format(".WithOptional(b => b.{0})", fkPropName);
+                        return string.Format(".WithOptional({0})", withParam);
 
                     case Relationship.OneToMany:
-                        return string.Format(".WithRequiredDependent(b => b.{0})", fkPropName);
+                        return string.Format(".WithRequiredDependent({0})", withParam);
 
                     case Relationship.ManyToOne:
                         if (!fkCol.Hidden)
-                            return string.Format(".WithMany(b => b.{0}).HasForeignKey({1})", fkPropName, manyToManyMapping);   // Foreign Key Association
-                        return string.Format(".WithMany(b => b.{0}).Map(c => c.MapKey({1}))", fkPropName, mapKey);  // Independent Association
+                            return string.Format(".WithMany({0}).HasForeignKey({1})", withParam, manyToManyMapping);   // Foreign Key Association
+                        return string.Format(".WithMany({0}).Map(c => c.MapKey({1}))", withParam, mapKey);  // Independent Association
 
                     case Relationship.ManyToMany:
-                        return string.Format(".WithMany(b => b.{0}).HasForeignKey({1})", fkPropName, manyToManyMapping);
+                        return string.Format(".WithMany({0}).HasForeignKey({1})", withParam, manyToManyMapping);
 
                     default:
                         throw new ArgumentOutOfRangeException("relationship");
@@ -2739,6 +2745,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             public string ConstraintName { get; private set; }
             public int Ordinal { get; private set; }
             public bool CascadeOnDelete { get; private set; }
+            public bool IncludeReverseNavigationProperty { get; set; }
 
             public ForeignKey(string fkTableName, string fkSchema, string pkTableName, string pkSchema, string fkColumn, string pkColumn, string constraintName, string fkTableNameFiltered, string pkTableNameFiltered, int ordinal, bool cascadeOnDelete)
             {
@@ -2753,6 +2760,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 PkTableNameFiltered = pkTableNameFiltered;
                 Ordinal = ordinal;
                 CascadeOnDelete = cascadeOnDelete;
+                IncludeReverseNavigationProperty = true;
             }
 
             public string PkTableHumanCase(bool useCamelCase, bool prependSchemaName)


### PR DESCRIPTION
New property on `ForeignKey` class called `IncludeReverseNavigationProperty` which controls whether the generated POCO class includes a reverse navigation property for the foreign key.  This property can be set in the ForeignKeyFilter delegate, giving the user control over which reverse navigation properties are generated.

Prior to this change all properties on `ForeignKey` were read-only (private setter), so this deviates a little from the current pattern, but is not dissimilar to other model classes such as `Table`.