### PR TITLE
Defaults and Collections are initialized using property initializers …

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -871,8 +871,8 @@
                     else
                         inlineComments += ". " + ExtendedProperty;
                 }
-
-                Entity = string.Format("public {0}{1} {2} {{ get; {3}set; }}{4}", (OverrideModifier ? "override " : ""), WrapIfNullable(PropertyType, this), NameHumanCase, usePrivateSetterForComputedColumns && IsComputed() ? "private " : string.Empty, inlineComments);
+				var initialization = (this.Default == string.Empty)?"" : string.Format(" = {0};", this.Default);
+                Entity = string.Format("public {0}{1} {2} {{ get; {3}set; }}{4}{5}", (OverrideModifier ? "override " : ""), WrapIfNullable(PropertyType, this), NameHumanCase, usePrivateSetterForComputedColumns && IsComputed() ? "private " : string.Empty, initialization, inlineComments);
             }
 
             private string WrapIfNullable(string propType, Column col)
@@ -3250,12 +3250,14 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         break;
 
                     case Relationship.ManyToOne:
-                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}", fkTable.NameHumanCase, propName, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty));
+						var initialization1 = string.Format(" = new {0}<{1}>();", collectionType, fkTable.NameHumanCase);
+                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}{3}", fkTable.NameHumanCase, propName, initialization1, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty));
                         ReverseNavigationCtor.Add(string.Format("{0} = new {1}<{2}>();", propName, collectionType, fkTable.NameHumanCase));
                         break;
 
                     case Relationship.ManyToMany:
-                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}", fkTable.NameHumanCase, propName, includeComments != CommentsStyle.None ? " // Many to many mapping" : string.Empty));
+						var initialization2 = string.Format(" = new {0}<{1}>();", collectionType, fkTable.NameHumanCase);
+                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}{3}", fkTable.NameHumanCase, propName, initialization2, includeComments != CommentsStyle.None ? " // Many to many mapping" : string.Empty));
                         ReverseNavigationCtor.Add(string.Format("{0} = new {1}<{2}>();", propName, collectionType, fkTable.NameHumanCase));
                         break;
 

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -1014,32 +1014,6 @@ foreach(var entityFk in tbl.Columns.SelectMany(x => x.EntityFk).OrderBy(o => o))
 <# } #>
         <#=entityFk #>
 <# } } #>
-<#
-if(tbl.Columns.Where(c => c.Default != string.Empty && !c.Hidden).Count() > 0 || tbl.ReverseNavigationCtor.Count() > 0 || MakeClassesPartial)
-{
-#>
-
-        public <#=tbl.NameHumanCase#>()
-        {
-<#
-foreach(Column col in tbl.Columns.OrderBy(x => x.Ordinal).Where(c => c.Default != string.Empty && !c.Hidden))
-{
-#>
-            <#=col.NameHumanCase #> = <#=col.Default #>;
-<# } #>
-<#
-foreach(string s in tbl.ReverseNavigationCtor)
-{
-#>
-            <#=s #>
-<# }
-if(MakeClassesPartial) {#>
-            InitializePartial();
-<#}#>        }
-<#if(MakeClassesPartial) {#>
-
-        partial void InitializePartial();
-<#} }#>
     }
 
 <# } }


### PR DESCRIPTION
Defaults and Collections are initialized using property initializers (C# 6.0), so that Entity Constructors could be removed. This allows one to create their own constructors in partial classes, allowing mandatory arguments, private constructors, etc.