### PR TITLE
Ability to setup a suffix for the generated entity classes.

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -113,6 +113,11 @@
     //     abc.hello will be AbcHello.
     PrependSchemaName = true;   // Control if the schema name is prepended to the table name
 
+    // Table Suffix ***********************************************************************************************************************
+    // Prepends the suffix to the generated classes names
+    // Ie. If TableSuffix is "Dto" then Order will be OrderDto
+    //     If TableSuffix is "Entity" then Order will be OrderEntity
+    TableSuffix = null; 
 
     // Filtering **************************************************************************************************************************
     // Use the following table/view name regex filters to include or exclude tables/views

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -66,6 +66,7 @@
         string ExtraWcfDataContractAttributes = "";
         static bool DisableGeographyTypes = false;
         bool PrependSchemaName = true;
+        string TableSuffix = null;
         Regex SchemaFilterExclude = null;
         Regex SchemaFilterInclude = null;
         Regex TableFilterExclude = null;
@@ -608,6 +609,7 @@
                     {
                         if(UseDataAnnotationsSchema)
                             t.SetupDataAnnotations();
+                        t.Suffix = TableSuffix;
                     }
 
                     // Work out if there are any foreign key relationship naming clashes
@@ -2600,7 +2602,8 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     if (relationship == Relationship.DoNotUse)
                         continue;
 
-                    string pkTableHumanCase = foreignKey.PkTableHumanCase(usePascalCase, prependSchemaName);
+                    string pkTableHumanCaseWithSuffix = foreignKey.PkTableHumanCase(usePascalCase, prependSchemaName, pkTable.Suffix);                    
+                    string pkTableHumanCase = foreignKey.PkTableHumanCase(usePascalCase, prependSchemaName, null);
                     string pkPropName = fkTable.GetUniqueColumnName(pkTableHumanCase, foreignKey, usePascalCase, checkForFkNameClashes, true, ForeignKeyName);
                     bool fkMakePropNameSingular = (relationship == Relationship.OneToOne);
                     string fkPropName = pkTable.GetUniqueColumnName(fkTable.NameHumanCase, foreignKey, usePascalCase, checkForFkNameClashes, fkMakePropNameSingular, ForeignKeyName);
@@ -2609,7 +2612,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     if (dataAnnotationsSchema)
                         dataAnnotation = string.Format("[ForeignKey(\"{0}\")] ", string.Join(", ", fkCols.Select(x => x.col.NameHumanCase).Distinct().ToArray()));
 
-                    fkCol.col.EntityFk.Add(string.Format("{0}public virtual {1} {2} {3}{4}", dataAnnotation, pkTableHumanCase, pkPropName, "{ get; set; }", includeComments != CommentsStyle.None ? " // " + foreignKey.ConstraintName : string.Empty));
+                    fkCol.col.EntityFk.Add(string.Format("{0}public virtual {1} {2} {3}{4}", dataAnnotation, pkTableHumanCaseWithSuffix, pkPropName, "{ get; set; }", includeComments != CommentsStyle.None ? " // " + foreignKey.ConstraintName : string.Empty));
 
                     string manyToManyMapping, mapKey;
                     if(foreignKeys.Count > 1)
@@ -3046,12 +3049,13 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 IncludeReverseNavigation = true;
             }
 
-            public string PkTableHumanCase(bool usePascalCase, bool prependSchemaName)
+            public string PkTableHumanCase(bool usePascalCase, bool prependSchemaName, string suffix)
             {
                 string singular = Inflector.MakeSingular(PkTableNameFiltered);
                 string pkTableHumanCase = (usePascalCase ? Inflector.ToTitleCase(singular) : singular).Replace(" ", "").Replace("$", "");
                 if (string.Compare(PkSchema, "dbo", StringComparison.OrdinalIgnoreCase) != 0 && prependSchemaName)
                     pkTableHumanCase = PkSchema + "_" + pkTableHumanCase;
+                pkTableHumanCase += suffix;
                 return pkTableHumanCase;
             }
         }
@@ -3077,6 +3081,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             public string Schema;
             public string Type;
             public string ClassName;
+            public string Suffix;
             public bool IsMapping;
             public bool IsView;
             public bool HasForeignKey;
@@ -3099,6 +3104,13 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 DataAnnotations = new List<string>();
             }
 
+            public string NameHumanCaseWithSuffix
+            {
+                get
+                {
+                    return NameHumanCase + Suffix;
+                }
+            }
             public void ResetNavigationProperties()
             {
                 MappingConfiguration = new List<string>();
@@ -3242,21 +3254,21 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 switch (relationship)
                 {
                     case Relationship.OneToOne:
-                        ReverseNavigationProperty.Add(string.Format("public virtual {0} {1} {{ get; set; }}{2}", fkTable.NameHumanCase, propName, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty));
+                        ReverseNavigationProperty.Add(string.Format("public virtual {0} {1} {{ get; set; }}{2}", fkTable.NameHumanCaseWithSuffix, propName, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty));
                         break;
 
                     case Relationship.OneToMany:
-                        ReverseNavigationProperty.Add(string.Format("public virtual {0} {1} {{ get; set; }}{2}", fkTable.NameHumanCase, propName, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty));
+                        ReverseNavigationProperty.Add(string.Format("public virtual {0} {1} {{ get; set; }}{2}", fkTable.NameHumanCaseWithSuffix, propName, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty));
                         break;
 
                     case Relationship.ManyToOne:
-                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}", fkTable.NameHumanCase, propName, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty));
-                        ReverseNavigationCtor.Add(string.Format("{0} = new {1}<{2}>();", propName, collectionType, fkTable.NameHumanCase));
+                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}", fkTable.NameHumanCaseWithSuffix, propName, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty));
+                        ReverseNavigationCtor.Add(string.Format("{0} = new {1}<{2}>();", propName, collectionType, fkTable.NameHumanCaseWithSuffix));
                         break;
 
                     case Relationship.ManyToMany:
-                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}", fkTable.NameHumanCase, propName, includeComments != CommentsStyle.None ? " // Many to many mapping" : string.Empty));
-                        ReverseNavigationCtor.Add(string.Format("{0} = new {1}<{2}>();", propName, collectionType, fkTable.NameHumanCase));
+                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}", fkTable.NameHumanCaseWithSuffix, propName, includeComments != CommentsStyle.None ? " // Many to many mapping" : string.Empty));
+                        ReverseNavigationCtor.Add(string.Format("{0} = new {1}<{2}>();", propName, collectionType, fkTable.NameHumanCaseWithSuffix));
                         break;
 
                     default:

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -83,7 +83,7 @@ foreach(var usingStatement in usingsAll.Distinct().OrderBy(x => x)) { #>
 foreach (Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase) select t)
 {
 #>
-        System.Data.Entity.DbSet<<#=tbl.NameHumanCase #>> <#=Inflector.MakePlural(tbl.NameHumanCase) #> { get; set; }<#if (IncludeComments != CommentsStyle.None)
+        System.Data.Entity.DbSet<<#=tbl.NameHumanCaseWithSuffix #>> <#=Inflector.MakePlural(tbl.NameHumanCase) #> { get; set; }<#if (IncludeComments != CommentsStyle.None)
 { #> // <#=tbl.Name #>
 <# }
 else
@@ -215,7 +215,7 @@ foreach(var usingStatement in usingsContext.Distinct().OrderBy(x => x)) { #>
 foreach(Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase) select t)
 {
 #>
-        public System.Data.Entity.DbSet<<#=tbl.NameHumanCase#>> <#=Inflector.MakePlural(tbl.NameHumanCase)#> { get; set; }<#if(IncludeComments != CommentsStyle.None){#> // <#=tbl.Name#>
+        public System.Data.Entity.DbSet<<#=tbl.NameHumanCaseWithSuffix#>> <#=Inflector.MakePlural(tbl.NameHumanCase)#> { get; set; }<#if(IncludeComments != CommentsStyle.None){#> // <#=tbl.Name#>
 <# } else { #>
 
 <# } #>
@@ -298,7 +298,7 @@ foreach(Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey
 foreach(Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey).Where(ConfigurationFilter).OrderBy(x => x.NameHumanCase) select t)
 {
 #>
-            modelBuilder.Configurations.Add(new <#=tbl.NameHumanCase + ConfigurationClassName#>());
+            modelBuilder.Configurations.Add(new <#=tbl.NameHumanCaseWithSuffix + ConfigurationClassName#>());
 <# } #>
 <#if(MakeClassesPartial) {#>
 
@@ -312,7 +312,7 @@ foreach(Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey
 foreach(Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey).Where(ConfigurationFilter).OrderBy(x => x.NameHumanCase) select t)
 {
 #>
-            modelBuilder.Configurations.Add(new <#=tbl.NameHumanCase + ConfigurationClassName#>(schema));
+            modelBuilder.Configurations.Add(new <#=tbl.NameHumanCaseWithSuffix + ConfigurationClassName#>(schema));
 <# } #>
             return modelBuilder;
         }
@@ -510,7 +510,7 @@ foreach(var usingStatement in usingsContext.Distinct().OrderBy(x => x)) { #>
 foreach (Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase) select t)
 {
 #>
-        public System.Data.Entity.DbSet<<#=tbl.NameHumanCase #>> <#=Inflector.MakePlural(tbl.NameHumanCase) #> { get; set; }
+        public System.Data.Entity.DbSet<<#=tbl.NameHumanCaseWithSuffix #>> <#=Inflector.MakePlural(tbl.NameHumanCase) #> { get; set; }
 <# } #>
 
         public Fake<#=DbContextName #>()
@@ -519,7 +519,7 @@ foreach (Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKe
 foreach (Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase) select t)
 {
 #>
-            <#=Inflector.MakePlural(tbl.NameHumanCase) #> = new FakeDbSet<<#=tbl.NameHumanCase #>>(<#= string.Join(", ", tbl.PrimaryKeys.Select(x => "\"" + x.NameHumanCase + "\"")) #>);
+            <#=Inflector.MakePlural(tbl.NameHumanCase) #> = new FakeDbSet<<#=tbl.NameHumanCaseWithSuffix #>>(<#= string.Join(", ", tbl.PrimaryKeys.Select(x => "\"" + x.NameHumanCase + "\"")) #>);
 <# } #>
 <#if(MakeClassesPartial) {#>
 
@@ -963,7 +963,7 @@ if (IncludeTableValuedFunctions)
 foreach(Table tbl in from t in tables.Where(t => !t.IsMapping).OrderBy(x => x.NameHumanCase) select t)
 {
 #>
-<# fileManager.StartNewFile(tbl.NameHumanCase + FileExtension);
+<# fileManager.StartNewFile(tbl.NameHumanCaseWithSuffix + FileExtension);
 if(!tbl.HasPrimaryKey) { #>
     // The table '<#=tbl.Name#>' is not usable by entity framework because it
     // does not have a primary key. It is listed here for completeness.
@@ -975,7 +975,7 @@ if(!tbl.HasPrimaryKey) { #>
     WritePocoClassAttributes(tbl);#>
 <#if(IncludeCodeGeneratedAttribute){#>    <#=CodeGeneratedAttribute#>
 <#}#>
-    public <# if(MakeClassesPartial) { #>partial <# } #>class <#=tbl.NameHumanCase#><#=WritePocoBaseClasses != null ? WritePocoBaseClasses(tbl) : "" #>
+    public <# if(MakeClassesPartial) { #>partial <# } #>class <#=tbl.NameHumanCaseWithSuffix#><#=WritePocoBaseClasses != null ? WritePocoBaseClasses(tbl) : "" #>
     {
 <# WritePocoBaseClassBody(tbl); #>
 <# int DataMemberOrder = 1;
@@ -1019,7 +1019,7 @@ if(tbl.Columns.Where(c => c.Default != string.Empty && !c.Hidden).Count() > 0 ||
 {
 #>
 
-        public <#=tbl.NameHumanCase#>()
+        public <#=tbl.NameHumanCaseWithSuffix#>()
         {
 <#
 foreach(Column col in tbl.Columns.OrderBy(x => x.Ordinal).Where(c => c.Default != string.Empty && !c.Hidden))
@@ -1056,19 +1056,19 @@ if(!GenerateSeparateFiles) { #>
 foreach(Table tbl in tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase))
 {
 #>
-<# fileManager.StartNewFile(tbl.NameHumanCase + ConfigurationClassName + FileExtension);
+<# fileManager.StartNewFile(tbl.NameHumanCaseWithSuffix + ConfigurationClassName + FileExtension);
 if(IncludeComments != CommentsStyle.None){#>    // <#=tbl.Name#>
 <# } #>
 <#if(IncludeCodeGeneratedAttribute){#>    <#=CodeGeneratedAttribute#>
 <#}#>
-    public <# if(MakeClassesPartial) { #>partial <# } #>class <#=tbl.NameHumanCase + ConfigurationClassName#> : System.Data.Entity.ModelConfiguration.EntityTypeConfiguration<<#=tbl.NameHumanCase#>>
+    public <# if(MakeClassesPartial) { #>partial <# } #>class <#=tbl.NameHumanCaseWithSuffix + ConfigurationClassName#> : System.Data.Entity.ModelConfiguration.EntityTypeConfiguration<<#=tbl.NameHumanCaseWithSuffix#>>
     {
-        public <#=tbl.NameHumanCase + ConfigurationClassName#>()
+        public <#=tbl.NameHumanCaseWithSuffix + ConfigurationClassName#>()
             : this(<# if (string.IsNullOrEmpty(tbl.Schema)) { #>""<# } else { #>"<#=tbl.Schema#>"<# } #>)
         {
         }
 
-        public <#=tbl.NameHumanCase + ConfigurationClassName#>(string schema)
+        public <#=tbl.NameHumanCaseWithSuffix + ConfigurationClassName#>(string schema)
         {
 <#if(!UseDataAnnotationsSchema){ if (!string.IsNullOrEmpty(tbl.Schema)) { #>
             ToTable("<#=tbl.Name#>", schema);


### PR DESCRIPTION
Ie. If TableSuffix is "Dto" then Order will be OrderDto
or If TableSuffix is "Entity" then Order will be OrderEntity.

I needed this in a project where the separation between data transfer objects and the domain models is requried, so I chose to suffix the generated classes.  

Using *TableRename* only didn't get the proper results since now the table names weren't singularized (ie. remained OrdersDto) and the Dto prefix appeared also in the relation properties (ie. OrdersDto.OrdersItemsDtos).