### PR TITLE
New configuration UsePropertyInitializers, which initializes Defaults…

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -55,6 +55,7 @@
         bool MakeDbContextInterfacePartial = false;
         bool GenerateSeparateFiles = false;
         bool UseMappingTables = true;
+        static bool UsePropertyInitializers = false;
         bool IsSqlCe = false;
         string FileExtension = ".cs";
         bool UsePascalCase = true;
@@ -882,8 +883,8 @@
                     else
                         inlineComments += ". " + ExtendedProperty;
                 }
-
-                Entity = string.Format("public {0}{1} {2} {{ get; {3}set; }}{4}", (OverrideModifier ? "override " : ""), WrapIfNullable(PropertyType, this), NameHumanCase, usePrivateSetterForComputedColumns && IsComputed() ? "private " : string.Empty, inlineComments);
+				var initialization = UsePropertyInitializers ? ((this.Default == string.Empty)?"" : string.Format(" = {0};", this.Default)) : "";
+                Entity = string.Format("public {0}{1} {2} {{ get; {3}set; }}{4}{5}", (OverrideModifier ? "override " : ""), WrapIfNullable(PropertyType, this), NameHumanCase, usePrivateSetterForComputedColumns && IsComputed() ? "private " : string.Empty, initialization, inlineComments);
             }
 
             private string WrapIfNullable(string propType, Column col)
@@ -3273,12 +3274,14 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         break;
 
                     case Relationship.ManyToOne:
-                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}", fkTable.NameHumanCaseWithSuffix, propName, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty));
+                        var initialization1 = UsePropertyInitializers ? (string.Format(" = new {0}<{1}>();", collectionType, fkTable.NameHumanCase)) : "";
+                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}{3}", fkTable.NameHumanCaseWithSuffix, propName, initialization1, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty));
                         ReverseNavigationCtor.Add(string.Format("{0} = new {1}<{2}>();", propName, collectionType, fkTable.NameHumanCaseWithSuffix));
                         break;
 
                     case Relationship.ManyToMany:
-                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}", fkTable.NameHumanCaseWithSuffix, propName, includeComments != CommentsStyle.None ? " // Many to many mapping" : string.Empty));
+                        var initialization2 = UsePropertyInitializers ? (string.Format(" = new {0}<{1}>();", collectionType, fkTable.NameHumanCase)) : "";
+                        ReverseNavigationProperty.Add(string.Format("public virtual System.Collections.Generic.ICollection<{0}> {1} {{ get; set; }}{2}", fkTable.NameHumanCaseWithSuffix, propName, initialization2, includeComments != CommentsStyle.None ? " // Many to many mapping" : string.Empty));
                         ReverseNavigationCtor.Add(string.Format("{0} = new {1}<{2}>();", propName, collectionType, fkTable.NameHumanCaseWithSuffix));
                         break;
 

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -1015,6 +1015,7 @@ foreach(var entityFk in tbl.Columns.SelectMany(x => x.EntityFk).OrderBy(o => o))
         <#=entityFk #>
 <# } } #>
 <#
+if (!UsePropertyInitializers){
 if(tbl.Columns.Where(c => c.Default != string.Empty && !c.Hidden).Count() > 0 || tbl.ReverseNavigationCtor.Count() > 0 || MakeClassesPartial)
 {
 #>
@@ -1039,7 +1040,8 @@ if(MakeClassesPartial) {#>
 <#if(MakeClassesPartial) {#>
 
         partial void InitializePartial();
-<#} }#>
+<#} }
+}#>
     }
 
 <# } }


### PR DESCRIPTION
… and Collections using property initializers (C# 6.0), and removes the entities public constructors.

This allows someone to create their own constructors in partial classes, which can be used to enforce passing mandatory arguments, setting private constructors, etc.

I've submitted this before #209, and it was breaking compatibility with C# 5.0. Now it's a configuration (UsePropertyInitializers) which by default is disabled.