### PR TITLE
Func ForeignKeyName now receives Relationship, so that it knows if th…

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -91,7 +91,7 @@
         static Func<string, StoredProcedure, string> StoredProcedureReturnModelRename;
         Func<Column, Table, Column> UpdateColumn;
         Func<ForeignKey, ForeignKey> ForeignKeyFilter;
-        Func<string, ForeignKey, string, short, string> ForeignKeyName;
+        Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName;
         string MigrationConfigurationFileName = null;
         string MigrationStrategy = "MigrateDatabaseToLatestVersion";
         string ContextKey = null;
@@ -1498,7 +1498,7 @@
             public abstract Tables ReadSchema(Regex schemaFilterExclude, Regex schemaFilterInclude, Regex tableFilterExclude, Regex tableFilterInclude, Regex columnFilterExclude, Func<Table, bool> tableFilter, bool usePascalCase, bool prependSchemaName, CommentsStyle includeComments, bool includeViews, CommentsStyle includeExtendedPropertyComments, Func<string, string, string> tableRename, Func<Column, Table, Column> updateColumn, bool usePrivateSetterForComputedColumns, bool includeSynonyms, bool dataAnnotations, bool dataAnnotationsSchema, bool isSqlCe);
             public abstract List<StoredProcedure> ReadStoredProcs(Regex SchemaFilterExclude, Regex storedProcedureFilterExclude, bool usePascalCase, bool prependSchemaName , Func<StoredProcedure, string> StoredProcedureRename, bool includeTableValuedFunctions);
             public abstract List<ForeignKey> ReadForeignKeys(Func<string, string, string> tableRename, Func<ForeignKey, ForeignKey> foreignKeyFilter);
-            public abstract void ProcessForeignKeys(List<ForeignKey> fkList, Tables tables, bool usePascalCase, bool prependSchemaName, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, Func<string, ForeignKey, string, short, string> ForeignKeyName, bool dataAnnotationsSchema);
+            public abstract void ProcessForeignKeys(List<ForeignKey> fkList, Tables tables, bool usePascalCase, bool prependSchemaName, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName, bool dataAnnotationsSchema);
             public abstract void IdentifyForeignKeys(List<ForeignKey> fkList, Tables tables);
             public abstract void ReadIndexes(Tables tables);
             public abstract void ReadExtendedProperties(Tables tables);
@@ -2567,7 +2567,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
             }
 
-            public override void ProcessForeignKeys(List<ForeignKey> fkList, Tables tables, bool usePascalCase, bool prependSchemaName, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, Func<string, ForeignKey, string, short, string> ForeignKeyName, bool dataAnnotationsSchema)
+            public override void ProcessForeignKeys(List<ForeignKey> fkList, Tables tables, bool usePascalCase, bool prependSchemaName, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName, bool dataAnnotationsSchema)
             {
                 var constraints = fkList.Select(x => x.FkSchema + "." + x.ConstraintName).Distinct();
                 foreach (var constraint in constraints)
@@ -2615,9 +2615,9 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
 
                     string pkTableHumanCaseWithSuffix = foreignKey.PkTableHumanCase(usePascalCase, prependSchemaName, pkTable.Suffix);
                     string pkTableHumanCase = foreignKey.PkTableHumanCase(usePascalCase, prependSchemaName, null);
-                    string pkPropName = fkTable.GetUniqueColumnName(pkTableHumanCase, foreignKey, usePascalCase, checkForFkNameClashes, true, ForeignKeyName);
+                    string pkPropName = fkTable.GetUniqueColumnName(pkTableHumanCase, foreignKey, usePascalCase, checkForFkNameClashes, true, ForeignKeyName, Relationship.ManyToOne);
                     bool fkMakePropNameSingular = (relationship == Relationship.OneToOne);
-                    string fkPropName = pkTable.GetUniqueColumnName(fkTable.NameHumanCase, foreignKey, usePascalCase, checkForFkNameClashes, fkMakePropNameSingular, ForeignKeyName);
+                    string fkPropName = pkTable.GetUniqueColumnName(fkTable.NameHumanCase, foreignKey, usePascalCase, checkForFkNameClashes, fkMakePropNameSingular, ForeignKeyName, Relationship.OneToMany);
 
                     var dataAnnotation = string.Empty;
                     if (dataAnnotationsSchema)
@@ -3180,7 +3180,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 return Columns.SingleOrDefault(x => String.Compare(x.Name, columnName, StringComparison.OrdinalIgnoreCase) == 0);
             }
 
-            public string GetUniqueColumnName(string tableNameHumanCase, ForeignKey foreignKey, bool usePascalCase, bool checkForFkNameClashes, bool makeSingular, Func<string, ForeignKey, string, short, string> ForeignKeyName)
+            public string GetUniqueColumnName(string tableNameHumanCase, ForeignKey foreignKey, bool usePascalCase, bool checkForFkNameClashes, bool makeSingular, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName, Relationship relationship)
             {
                 if (ReverseNavigationUniquePropName.Count == 0)
                 {
@@ -3196,7 +3196,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
 
                 // Attempt 1
                 string fkName = (usePascalCase ? Inflector.ToTitleCase(foreignKey.FkColumn) : foreignKey.FkColumn).Replace(" ", "").Replace("$", "");
-                string name = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, 1);
+                string name = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 1);
                 string col;
                 if (!ReverseNavigationUniquePropNameClashes.Contains(name) && !ReverseNavigationUniquePropName.Contains(name))
                 {
@@ -3207,7 +3207,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 2
                 if (fkName.ToLowerInvariant().EndsWith("id"))
                 {
-                    col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, 2);
+                    col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 2);
                     if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                         !ReverseNavigationUniquePropNameClashes.Contains(col))
                         ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -3221,7 +3221,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 3
-                col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, 3);
+                col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 3);
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                     !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -3234,7 +3234,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Attempt 4
-                col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, 4);
+                col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 4);
                 if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) && !ReverseNavigationUniquePropNameClashes.Contains(col))
                     ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
 
@@ -3247,7 +3247,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 // Attempt 5
                 for (int n = 1; n < 99; ++n)
                 {
-                    col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, 5) + n;
+                    col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 5) + n;
 
                     if (ReverseNavigationUniquePropName.Contains(col))
                         continue;
@@ -3257,7 +3257,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
 
                 // Give up
-                return ForeignKeyName(tableNameHumanCase, foreignKey, fkName, 6);
+                return ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 6);
             }
 
             public void AddReverseNavigation(Relationship relationship, string fkName, Table fkTable, string propName, string constraint, string collectionType, CommentsStyle includeComments)
@@ -3297,7 +3297,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             }});", leftPropName, rightPropName, left.FkTableName, left.FkColumn, right.FkColumn, isSqlCe ? string.Empty : ", \"" + left.FkSchema + "\""));
             }
 
-            public void IdentifyMappingTable(List<ForeignKey> fkList, Tables tables, bool usePascalCase, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, bool isSqlCe, Func<string, ForeignKey, string, short, string> ForeignKeyName)
+            public void IdentifyMappingTable(List<ForeignKey> fkList, Tables tables, bool usePascalCase, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, bool isSqlCe, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName)
             {
                 IsMapping = false;
 
@@ -3338,8 +3338,8 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 if (rightTable == null)
                     return;
 
-                var leftPropName  = leftTable.GetUniqueColumnName(rightTable.NameHumanCase, right, usePascalCase, checkForFkNameClashes, false, ForeignKeyName);
-                var rightPropName = rightTable.GetUniqueColumnName(leftTable.NameHumanCase, left, usePascalCase, checkForFkNameClashes, false, ForeignKeyName);
+                var leftPropName  = leftTable.GetUniqueColumnName(rightTable.NameHumanCase, right, usePascalCase, checkForFkNameClashes, false, ForeignKeyName, Relationship.ManyToOne); // relationship from the mapping table to each side is Many-to-One
+                var rightPropName = rightTable.GetUniqueColumnName(leftTable.NameHumanCase, left, usePascalCase, checkForFkNameClashes, false, ForeignKeyName, Relationship.ManyToOne); // relationship from the mapping table to each side is Many-to-One
                 leftTable.AddMappingConfiguration(left, right, usePascalCase, leftPropName, rightPropName, isSqlCe);
 
                 IsMapping = true;
@@ -3376,7 +3376,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
             }
 
-            public void IdentifyMappingTables(List<ForeignKey> fkList, bool usePascalCase, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, bool isSqlCe, Func<string, ForeignKey, string, short, string> ForeignKeyName)
+            public void IdentifyMappingTables(List<ForeignKey> fkList, bool usePascalCase, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, bool isSqlCe, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName)
             {
                 foreach(var tbl in this.Where(x => x.HasForeignKey))
                 {


### PR DESCRIPTION
…is a one-to-many (PK table pointing to FK table) or a many-to-one (FK table pointing to PK table), and can use that information to derive the relationship names (both ways) from the constraint name.

This replaces #207 

Sample usage:

    ForeignKeyName = (tableName, foreignKey, foreignKeyName, relationship, attempt) =>
    {
        ....
        //FK_TableName_FromThisToParentRelationshipName_FromParentToThisChildsRelationshipName (e.g. FK_CustomerAddress_Customer_Addresses will extract navigation properties "address.Customer" and "customer.Addresses")
        if (foreignKey.ConstraintName.StartsWith("FK_") && foreignKey.ConstraintName.Count(x=>x=='_')==3)
        {
            var parts = foreignKey.ConstraintName.Split('_');
            if (!string.IsNullOrWhiteSpace(parts[2]) && !string.IsNullOrWhiteSpace(parts[3]))
            {
                if (relationship==Relationship.OneToMany)
                    fkName = parts[3];
                else if (relationship==Relationship.ManyToOne)
                    fkName = parts[2];
            }
        }
        ....
    }