### PR TITLE
Bug in CalcRelationship & CalcRelationshipSingle

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -735,53 +735,38 @@
             DoNotUse
         }
 
-        public static Relationship CalcRelationship(Table pkTable, Table fkTable, List<Column> fkCols, List<Column> pkCols)
+        // Calculates the relationship between a child table and it's parent table.
+		public static Relationship CalcRelationship(Table parentTable, Table childTable, List<Column> childTableCols, List<Column> parentTableCols)
         {
-            if (fkCols.Count() == 1 && pkCols.Count() == 1)
-                return CalcRelationshipSingle(pkTable, fkTable, fkCols.First(), pkCols.First());
+            if (childTableCols.Count() == 1 && parentTableCols.Count() == 1)
+                return CalcRelationshipSingle(parentTable, childTable, childTableCols.First(), parentTableCols.First());
 
             // This relationship has multiple composite keys
 
-            bool fkTableAllPrimaryKeys = (fkTable.PrimaryKeys.Count() == fkCols.Count());
-            bool pkTableAllPrimaryKeys = (pkTable.PrimaryKeys.Count() == pkCols.Count());
-            bool fkColumnsAllPrimaryKeys = (fkCols.Count(x => x.IsPrimaryKey) == fkCols.Count());
-            bool pkColumnsAllPrimaryKeys = (pkCols.Count(x => x.IsPrimaryKey) == pkCols.Count());
+			// childTable FK columns are exactly the primary key (they are part of primary key, and no other columns are primary keys) //TODO: we could also check if they are an unique index
+            bool childTableColumnsAllPrimaryKeys = (childTableCols.Count() == childTableCols.Count(x => x.IsPrimaryKey)) && (childTableCols.Count() == childTable.PrimaryKeys.Count());
+            
+			// parentTable columns are exactly the primary key (they are part of primary key, and no other columns are primary keys) //TODO: we could also check if they are an unique index
+			bool parentTableColumnsAllPrimaryKeys = (parentTableCols.Count() == parentTableCols.Count(x => x.IsPrimaryKey)) && (parentTableCols.Count() == parentTable.PrimaryKeys.Count());
 
-            // 1:1
-            if(fkColumnsAllPrimaryKeys && pkColumnsAllPrimaryKeys && fkTableAllPrimaryKeys && pkTableAllPrimaryKeys)
+            // childTable FK columns are not only FK but also the whole PK (not only part of PK); parentTable columns are the whole PK (not only part of PK) - so it's 1:1
+            if(childTableColumnsAllPrimaryKeys && parentTableColumnsAllPrimaryKeys)
                 return Relationship.OneToOne;
 
-            // 1:n
-            if(fkColumnsAllPrimaryKeys && !pkColumnsAllPrimaryKeys && fkTableAllPrimaryKeys)
-                return Relationship.OneToMany;
-
-            // n:1
-            if(!fkColumnsAllPrimaryKeys && pkColumnsAllPrimaryKeys && pkTableAllPrimaryKeys)
-                return Relationship.ManyToOne;
-
-            // n:n
-            return Relationship.ManyToMany;
+			return Relationship.ManyToOne;
         }
 
-        public static Relationship CalcRelationshipSingle(Table pkTable, Table fkTable, Column fkCol, Column pkCol)
+        // Calculates the relationship between a child table and it's parent table.
+		public static Relationship CalcRelationshipSingle(Table parentTable, Table childTable, Column childTableCol, Column parentTableCol)
         {
-            bool fkTableSinglePrimaryKey = (fkTable.PrimaryKeys.Count() == 1);
-            bool pkTableSinglePrimaryKey = (pkTable.PrimaryKeys.Count() == 1);
+            bool childTableSinglePrimaryKey = (childTable.PrimaryKeys.Count() == 1);
+            bool parentTableSinglePrimaryKey = (parentTable.PrimaryKeys.Count() == 1);
 
             // 1:1
-            if(fkCol.IsPrimaryKey && pkCol.IsPrimaryKey && fkTableSinglePrimaryKey && pkTableSinglePrimaryKey)
+            if(childTableCol.IsPrimaryKey && parentTableCol.IsPrimaryKey && childTableSinglePrimaryKey && parentTableSinglePrimaryKey)
                 return Relationship.OneToOne;
 
-            // 1:n
-            if(fkCol.IsPrimaryKey && !pkCol.IsPrimaryKey && fkTableSinglePrimaryKey)
-                return Relationship.OneToMany;
-
-            // n:1
-            if(!fkCol.IsPrimaryKey && pkCol.IsPrimaryKey && pkTableSinglePrimaryKey)
-                return Relationship.ManyToOne;
-
-            // n:n
-            return Relationship.ManyToMany;
+            return Relationship.ManyToOne;
         }
 
         public class EnumDefinition


### PR DESCRIPTION
`CalcRelationship` & `CalcRelationshipSingle` should return the relationship between a child table and it's parent table - so it can only be One-to-One or Many-To-One. 
The many-to-many detection already exists in IdentifyMappingTable, so it shouldn't exist in these 2 functions above, because a relationship between 2 tables can never be Many-to-Many.

As a consequence (incorrect logic), it's incorrectly returning Many-to-Many in some cases, which throws a null exception with some recent merges (see below). This PR fixes those `CalcRelationship` & `CalcRelationshipSingle` to correctly dectect only One-to-One and Many-to-One.

For reproducing the problem: create a table `Table1` (PK `Table1ID`), table `Table2` (PK `Table2ID`), and table `Table3` (PK `Table1ID`/`Table2ID`, `Table1ID` FK to Table1, `Table2ID` FK to Table2, AND additional columns so that this should NOT be treated as a mapping-table).
It will throw an exception in the AddReverseNavigation because it will try to create a many-to-many relationship (incorrectly), and mappingTable is null (because mappingTable is only passed from the IdentifyMappingTable method).