### PR TITLE
Fix varbinary not including the (max) when it's type is maximum.

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -2460,7 +2460,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     ParentTable = table
                 };
 
-                if (col.MaxLength == -1 && col.SqlPropertyType.EndsWith("varchar", StringComparison.InvariantCultureIgnoreCase))
+                if (col.MaxLength == -1 && (col.SqlPropertyType.EndsWith("varchar", StringComparison.InvariantCultureIgnoreCase) || col.SqlPropertyType.EndsWith("varbinary", StringComparison.InvariantCultureIgnoreCase)))
                     col.SqlPropertyType += "(max)";
 
                 if (col.IsPrimaryKey && !col.IsIdentity && col.IsStoreGenerated && typename == "uniqueidentifier")


### PR DESCRIPTION
Fix for Bug #241 - SQL varbinary (max) not being set.