### PR TITLE
CodeFirstFunctions ResultColumnName support

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -477,7 +477,7 @@ if (IncludeTableValuedFunctions)
             string spReturnClassName = WriteStoredProcReturnModelName(sp);
 #>
         [System.Data.Entity.DbFunction("<#=DbContextName#>", "<#=sp.Name#>")]
-        [CodeFirstStoreFunctions.DbFunctionDetails(DatabaseSchema = "<#=sp.Schema#>")]
+        [CodeFirstStoreFunctions.DbFunctionDetails(DatabaseSchema = "<#=sp.Schema#>"<#if (sp.ReturnModels.Count == 1 && sp.ReturnModels[0].Count == 1) {#>, ResultColumnName = "<#=sp.ReturnModels[0][0].ColumnName#>"<#}#>)]
         public IQueryable<<#= spReturnClassName #>> <#= spExecName #>(<#=WriteStoredProcFunctionParams(sp, false)#>)
         {
 <#= WriteTableValuedFunctionDeclareSqlParameter(sp) #>


### PR DESCRIPTION
To use code first functions result column, add stored procedure mapping to .NET built-in type:
StoredProcedureReturnTypes.Add("GetRelatedProducts", "long");
Nullable:
StoredProcedureReturnTypes.Add("GetRelatedProducts", "long?");