### PR TITLE
Fix unbalanced `#region Unit of work` and `#endregion` when generating separate files

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -190,7 +190,7 @@ if (IncludeTableValuedFunctions)
     }
 
 <# }
-if(ElementsToGenerate.HasFlag(Elements.UnitOfWork) && !string.IsNullOrWhiteSpace(DbContextInterfaceName)) { #>
+if(ElementsToGenerate.HasFlag(Elements.UnitOfWork) && !string.IsNullOrWhiteSpace(DbContextInterfaceName) && !GenerateSeparateFiles) { #>
     #endregion
 
 <# }


### PR DESCRIPTION
Fixes #287