### PR TITLE
Helper for base-class definition

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -323,6 +323,16 @@
     {
         //if (t.ClassName == "User")
         //    return ": IdentityUser<int, CustomUserLogin, CustomUserRole, CustomUserClaim>";
+
+        // or use the maker class to dynamically build more complex definitions
+        //var r = new BaseClassMaker("POCO.Sample.Data.MetaModelObject");
+        //r.AddInterface("POCO.Sample.Data.IObjectWithTableName");
+        //r.AddInterface("POCO.Sample.Data.IObjectWithId",
+        //    t.Columns.Any(x => x.IsPrimaryKey && !x.IsNullable && x.NameHumanCase.Equals("Id", StringComparison.InvariantCultureIgnoreCase) && x.PropertyType == "long"));
+        //r.AddInterface("POCO.Sample.Data.IObjectWithUserId",
+        //    t.Columns.Any(x => !x.IsPrimaryKey && !x.IsNullable && x.NameHumanCase.Equals("IdUsera", StringComparison.InvariantCultureIgnoreCase) && x.PropertyType == "long"));
+        //return r.ToString();
+
         return "";
     };
 

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -3687,4 +3687,76 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             var spReturnClassName = WriteStoredProcReturnModelName(sp);
             return (returnModelCount == 1) ? string.Format("System.Collections.Generic.List<{0}>", spReturnClassName) : spReturnClassName;
         };
+
+/// <summary>
+/// Helper class in making dynamic class definitions easier.
+/// </summary>
+public sealed class BaseClassMaker
+{
+    private string _typeName;
+    private System.Text.StringBuilder _interfaces;
+
+    public BaseClassMaker(string baseClassName = null)
+    {
+        SetBaseClassName(baseClassName);
+    }
+
+    /// <summary>
+    /// Sets the base-class name.
+    /// </summary>
+    public void SetBaseClassName(string typeName)
+    {
+        _typeName = typeName;
+    }
+
+    /// <summary>
+    /// Appends additional implemented interface.
+    /// </summary>
+    public bool AddInterface(string typeName)
+    {
+        if (string.IsNullOrEmpty(typeName))
+            return false;
+
+        if (_interfaces == null)
+        {
+            _interfaces = new System.Text.StringBuilder();
+        }
+        else
+        {
+            if (_interfaces.Length > 0)
+            {
+                _interfaces.Append(", ");
+            }
+        }
+
+        _interfaces.Append(typeName);
+        return true;
+    }
+
+    /// <summary>
+    /// Conditionally appends additional implemented interface.
+    /// </summary>
+    public bool AddInterface(string interfaceName, bool condition)
+    {
+        if (condition)
+        {
+            return AddInterface(interfaceName);
+        }
+
+        return false;
+    }
+
+    public override string ToString()
+    {
+        var hasInterfaces = _interfaces != null && _interfaces.Length > 0;
+
+        if (string.IsNullOrEmpty(_typeName))
+        {
+            return hasInterfaces ? " : " + _interfaces : string.Empty;
+        }
+
+        return hasInterfaces ? string.Concat(" : ", _typeName, ", ", _interfaces) : " : " + _typeName;
+    }
+}
+
 #>


### PR DESCRIPTION
In my daily project there are 7+ interfaces the generated model classes can implement based on the extracted columns from the table. Also views have different base class than regular tables, so I came up with this little build-in utility that makes the `WritePocoBaseClasses()` method a bit cleaner.