### PR TITLE
Defining custom annotations to each Navigation Property separately

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -458,6 +458,21 @@
         return fkName;
     };
 
+    /*
+    ForeignKeyAnnotationsProcessing = (Table fkTable, Table pkTable, string propName) =>
+    {
+        // each navigation property that is a reference to User are left intact
+        if (pkTable.NameHumanCase.Equals("User"))
+        {
+            if (propName.Equals("User"))
+                return null;
+        }
+
+        // all the others are marked with this attribute
+        return new[] { "System.Runtime.Serialization.IgnoreDataMember" };
+    };
+    */
+
     // Return true to include this table in the db context
     ConfigurationFilter = (Table t) =>
     {

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -93,6 +93,7 @@
         static Func<string, StoredProcedure, string> StoredProcedureReturnModelRename;
         Func<Column, Table, Column> UpdateColumn;
         Func<IList<ForeignKey>, Table, Table, bool, ForeignKey> ForeignKeyProcessing;
+        Func<Table, Table, string, string[]> ForeignKeyAnnotationsProcessing;
         Func<ForeignKey, ForeignKey> ForeignKeyFilter;
         Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName;
         string MigrationConfigurationFileName = null;
@@ -638,17 +639,17 @@
                     }
 
                     // Work out if there are any foreign key relationship naming clashes
-                    reader.ProcessForeignKeys(fkList, tables, UsePascalCase, PrependSchemaName, CollectionType, true, IncludeComments, ForeignKeyName, UseDataAnnotationsSchema, ForeignKeyProcessing);
+                    reader.ProcessForeignKeys(fkList, tables, UsePascalCase, PrependSchemaName, CollectionType, true, IncludeComments, ForeignKeyName, UseDataAnnotationsSchema, ForeignKeyProcessing, ForeignKeyAnnotationsProcessing);
                     if(UseMappingTables)
-                        tables.IdentifyMappingTables(fkList, UsePascalCase, CollectionType, true, IncludeComments, IsSqlCe, ForeignKeyName);
+                        tables.IdentifyMappingTables(fkList, UsePascalCase, CollectionType, true, IncludeComments, IsSqlCe, ForeignKeyName, ForeignKeyAnnotationsProcessing);
 
                     // Now we know our foreign key relationships and have worked out if there are any name clashes,
                     // re-map again with intelligently named relationships.
                     tables.ResetNavigationProperties();
 
-                    reader.ProcessForeignKeys(fkList, tables, UsePascalCase, PrependSchemaName, CollectionType, false, IncludeComments, ForeignKeyName, UseDataAnnotationsSchema, ForeignKeyProcessing);
+                    reader.ProcessForeignKeys(fkList, tables, UsePascalCase, PrependSchemaName, CollectionType, false, IncludeComments, ForeignKeyName, UseDataAnnotationsSchema, ForeignKeyProcessing, ForeignKeyAnnotationsProcessing);
                     if(UseMappingTables)
-                        tables.IdentifyMappingTables(fkList, UsePascalCase, CollectionType, false, IncludeComments, IsSqlCe, ForeignKeyName);
+                        tables.IdentifyMappingTables(fkList, UsePascalCase, CollectionType, false, IncludeComments, IsSqlCe, ForeignKeyName, ForeignKeyAnnotationsProcessing);
 
                     conn.Close();
                     return tables;
@@ -805,6 +806,7 @@
         {
             public string Definition;
             public string Comments;
+            public string[] AdditionalDataAnnotations;
         }
 
         public class Column
@@ -1499,7 +1501,7 @@
             public abstract Tables ReadSchema(Regex schemaFilterExclude, Regex schemaFilterInclude, Regex tableFilterExclude, Regex tableFilterInclude, Regex columnFilterExclude, Func<Table, bool> tableFilter, bool usePascalCase, bool prependSchemaName, CommentsStyle includeComments, bool includeViews, CommentsStyle includeExtendedPropertyComments, Func<string, string, bool, string> tableRename, Func<Column, Table, Column> updateColumn, bool usePrivateSetterForComputedColumns, bool includeSynonyms, bool dataAnnotations, bool dataAnnotationsSchema, bool isSqlCe, Dictionary<string, string> columnNameToDataAnnotation, bool includeConnectionSettingComments);
             public abstract List<StoredProcedure> ReadStoredProcs(Regex SchemaFilterExclude, Regex storedProcedureFilterExclude, bool usePascalCase, bool prependSchemaName , Func<StoredProcedure, string> StoredProcedureRename, bool includeTableValuedFunctions, bool includeConnectionSettingComments);
             public abstract List<ForeignKey> ReadForeignKeys(Func<string, string, bool, string> tableRename, Func<ForeignKey, ForeignKey> foreignKeyFilter);
-            public abstract void ProcessForeignKeys(List<ForeignKey> fkList, Tables tables, bool usePascalCase, bool prependSchemaName, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName, bool dataAnnotationsSchema, Func<IList<ForeignKey>, Table, Table, bool, ForeignKey> foreignKeyProcessing);
+            public abstract void ProcessForeignKeys(List<ForeignKey> fkList, Tables tables, bool usePascalCase, bool prependSchemaName, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName, bool dataAnnotationsSchema, Func<IList<ForeignKey>, Table, Table, bool, ForeignKey> foreignKeyProcessing, Func<Table, Table, string, string[]> foreignKeyAnnotationsProcessing);
             public abstract void IdentifyForeignKeys(List<ForeignKey> fkList, Tables tables);
             public abstract void ReadIndexes(Tables tables);
             public abstract void ReadExtendedProperties(Tables tables, bool includeConnectionSettingComments);
@@ -2607,7 +2609,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
             }
 
-            public override void ProcessForeignKeys(List<ForeignKey> fkList, Tables tables, bool usePascalCase, bool prependSchemaName, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName, bool dataAnnotationsSchema, Func<IList<ForeignKey>, Table, Table, bool, ForeignKey> foreignKeyProcessing)
+            public override void ProcessForeignKeys(List<ForeignKey> fkList, Tables tables, bool usePascalCase, bool prependSchemaName, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName, bool dataAnnotationsSchema, Func<IList<ForeignKey>, Table, Table, bool, ForeignKey> foreignKeyProcessing, Func<Table, Table, string, string[]> foreignKeyAnnotationsProcessing)
             {
                 var constraints = fkList.Select(x => x.FkSchema + "." + x.ConstraintName).Distinct();
                 foreach (var constraint in constraints)
@@ -2670,6 +2672,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     }
 
                     var fkd = new PropertyAndComments();
+                    fkd.AdditionalDataAnnotations = foreignKeyAnnotationsProcessing != null ? foreignKeyAnnotationsProcessing(fkTable, pkTable, pkPropName) : null;
                     fkd.Definition = string.Format("{0}public {1}{2} {3} {4}{5}", dataAnnotation, Table.GetLazyLoadingMarker(), pkTableHumanCaseWithSuffix, pkPropName, "{ get; set; }", includeComments != CommentsStyle.None ? " // " + foreignKey.ConstraintName : string.Empty);
                     fkd.Comments = string.Format("Parent {0} pointed by [{1}].({2}) ({3})", pkTableHumanCase, fkTable.Name, string.Join(", ", fkCols.Select(x => "[" + x.col.NameHumanCase + "]").Distinct().ToArray()), foreignKey.ConstraintName);
                     fkCol.col.EntityFk.Add(fkd);
@@ -2691,7 +2694,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     }
 
                     if(foreignKey.IncludeReverseNavigation)
-                        pkTable.AddReverseNavigation(relationship, pkTableHumanCase, fkTable, fkPropName, string.Format("{0}.{1}", fkTable.Name, foreignKey.ConstraintName), collectionType, includeComments, foreignKeys);
+                        pkTable.AddReverseNavigation(relationship, pkTableHumanCase, fkTable, fkPropName, string.Format("{0}.{1}", fkTable.Name, foreignKey.ConstraintName), collectionType, includeComments, foreignKeys, foreignKeyAnnotationsProcessing);
                 }
             }
 
@@ -3317,7 +3320,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 return ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 6);
             }
 
-            public void AddReverseNavigation(Relationship relationship, string fkName, Table fkTable, string propName, string constraint, string collectionType, CommentsStyle includeComments, List<ForeignKey> fks, Table mappingTable = null)
+            public void AddReverseNavigation(Relationship relationship, string fkName, Table fkTable, string propName, string constraint, string collectionType, CommentsStyle includeComments, List<ForeignKey> fks, Func<Table, Table, string, string[]> foreignKeyAnnotationsProcessing = null, Table mappingTable = null)
             {
                 string fkNames = "";
                 switch (relationship)
@@ -3339,6 +3342,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         ReverseNavigationProperty.Add(
                             new PropertyAndComments()
                             {
+                                AdditionalDataAnnotations = foreignKeyAnnotationsProcessing != null ? foreignKeyAnnotationsProcessing(fkTable, this, propName) : null,
                                 Definition = string.Format("public {0}{1} {2} {{ get; set; }}{3}", GetLazyLoadingMarker(), fkTable.NameHumanCaseWithSuffix, propName, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty),
                                 Comments = string.Format("Parent (One-to-One) {0} pointed by [{1}].{2} ({3})", this.NameHumanCaseWithSuffix, fkTable.Name, fkNames, fks.First().ConstraintName)
                             }
@@ -3349,6 +3353,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         ReverseNavigationProperty.Add(
                             new PropertyAndComments()
                             {
+                                AdditionalDataAnnotations = foreignKeyAnnotationsProcessing != null ? foreignKeyAnnotationsProcessing(fkTable, this, propName) : null,
                                 Definition = string.Format("public {0}{1} {2} {{ get; set; }}{3}", GetLazyLoadingMarker(), fkTable.NameHumanCaseWithSuffix, propName, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty),
                                 Comments = string.Format("Parent {0} pointed by [{1}].{2} ({3})", NameHumanCaseWithSuffix, fkTable.Name, fkNames, fks.First().ConstraintName)
                             }
@@ -3362,6 +3367,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         ReverseNavigationProperty.Add(
                             new PropertyAndComments()
                             {
+                                AdditionalDataAnnotations = foreignKeyAnnotationsProcessing != null ? foreignKeyAnnotationsProcessing(fkTable, this, propName) : null,
                                 Definition = string.Format("public {0}System.Collections.Generic.ICollection<{1}> {2} {{ get; set; }}{3}{4}", GetLazyLoadingMarker(), fkTable.NameHumanCaseWithSuffix, propName, initialization1, includeComments != CommentsStyle.None ? " // " + constraint : string.Empty),
                                 Comments = string.Format("Child {0} where [{1}].{2} point to this entity ({3})", Inflector.MakePlural(fkTable.NameHumanCase), fkTable.Name, fkNames, fks.First().ConstraintName)
                             }
@@ -3376,6 +3382,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         ReverseNavigationProperty.Add(
                             new PropertyAndComments()
                             {
+                                AdditionalDataAnnotations = foreignKeyAnnotationsProcessing != null ? foreignKeyAnnotationsProcessing(fkTable, this, propName) : null,
                                 Definition = string.Format("public {0}System.Collections.Generic.ICollection<{1}> {2} {{ get; set; }}{3}{4}", GetLazyLoadingMarker(), fkTable.NameHumanCaseWithSuffix, propName, initialization2, includeComments != CommentsStyle.None ? " // Many to many mapping" : string.Empty),
                                 Comments = string.Format("Child {0} (Many-to-Many) mapped by table [{1}]", Inflector.MakePlural(fkTable.NameHumanCase), mappingTable == null ? string.Empty : mappingTable.Name)
                             }
@@ -3399,7 +3406,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             }});", leftPropName, rightPropName, left.FkTableName, left.FkColumn, right.FkColumn, isSqlCe ? string.Empty : ", \"" + left.FkSchema + "\""));
             }
 
-            public void IdentifyMappingTable(List<ForeignKey> fkList, Tables tables, bool usePascalCase, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, bool isSqlCe, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName)
+            public void IdentifyMappingTable(List<ForeignKey> fkList, Tables tables, bool usePascalCase, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, bool isSqlCe, Func<string, ForeignKey, string, Relationship, short, string> foreignKeyName, Func<Table, Table, string, string[]> foreignKeyAnnotationsProcessing)
             {
                 IsMapping = false;
 
@@ -3440,13 +3447,13 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 if (rightTable == null)
                     return;
 
-                var leftPropName  = leftTable.GetUniqueColumnName(rightTable.NameHumanCase, right, usePascalCase, checkForFkNameClashes, false, ForeignKeyName, Relationship.ManyToOne); // relationship from the mapping table to each side is Many-to-One
-                var rightPropName = rightTable.GetUniqueColumnName(leftTable.NameHumanCase, left, usePascalCase, checkForFkNameClashes, false, ForeignKeyName, Relationship.ManyToOne); // relationship from the mapping table to each side is Many-to-One
+                var leftPropName  = leftTable.GetUniqueColumnName(rightTable.NameHumanCase, right, usePascalCase, checkForFkNameClashes, false, foreignKeyName, Relationship.ManyToOne); // relationship from the mapping table to each side is Many-to-One
+                var rightPropName = rightTable.GetUniqueColumnName(leftTable.NameHumanCase, left, usePascalCase, checkForFkNameClashes, false, foreignKeyName, Relationship.ManyToOne); // relationship from the mapping table to each side is Many-to-One
                 leftTable.AddMappingConfiguration(left, right, usePascalCase, leftPropName, rightPropName, isSqlCe);
 
                 IsMapping = true;
-                rightTable.AddReverseNavigation(Relationship.ManyToMany, rightTable.NameHumanCase, leftTable, rightPropName, null, collectionType, includeComments, null, mappingTable: this);
-                leftTable .AddReverseNavigation(Relationship.ManyToMany, leftTable.NameHumanCase, rightTable, leftPropName, null, collectionType, includeComments, null, mappingTable: this);
+                rightTable.AddReverseNavigation(Relationship.ManyToMany, rightTable.NameHumanCase, leftTable, rightPropName, null, collectionType, includeComments, null, foreignKeyAnnotationsProcessing, this);
+                leftTable.AddReverseNavigation(Relationship.ManyToMany, leftTable.NameHumanCase, rightTable, leftPropName, null, collectionType, includeComments, null, foreignKeyAnnotationsProcessing, this);
             }
 
             public void SetupDataAnnotations()
@@ -3478,11 +3485,11 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 }
             }
 
-            public void IdentifyMappingTables(List<ForeignKey> fkList, bool usePascalCase, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, bool isSqlCe, Func<string, ForeignKey, string, Relationship, short, string> ForeignKeyName)
+            public void IdentifyMappingTables(List<ForeignKey> fkList, bool usePascalCase, string collectionType, bool checkForFkNameClashes, CommentsStyle includeComments, bool isSqlCe, Func<string, ForeignKey, string, Relationship, short, string> foreignKeyName, Func<Table, Table, string, string[]> foreignKeyAnnotationsProcessing)
             {
                 foreach(var tbl in this.Where(x => x.HasForeignKey))
                 {
-                    tbl.IdentifyMappingTable(fkList, this, usePascalCase, collectionType, checkForFkNameClashes, includeComments, isSqlCe, ForeignKeyName);
+                    tbl.IdentifyMappingTable(fkList, this, usePascalCase, collectionType, checkForFkNameClashes, includeComments, isSqlCe, foreignKeyName, foreignKeyAnnotationsProcessing);
                 }
             }
 

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -987,31 +987,42 @@ if(tbl.ReverseNavigationProperty.Count() > 0)
 <# } #>
 <#
 foreach(var s in tbl.ReverseNavigationProperty.OrderBy(x => x.Definition))
-{
-    foreach (var rnpda in AdditionalReverseNavigationsDataAnnotations) {#>
-        [<#=rnpda #>]
-<# } #>
-<#if(IncludeComments != CommentsStyle.None){#>        /// <summary>
+{ #>
+
+<# if(IncludeComments != CommentsStyle.None){#>        /// <summary>
         /// <#=s.Comments ?? "" #>
         /// </summary>
-<# } #>
+<# }
+   foreach (var rnpda in AdditionalReverseNavigationsDataAnnotations) {#>
+        [<#=rnpda #>]
+<# }
+   if (s.AdditionalDataAnnotations != null) {
+     foreach (var fkda in s.AdditionalDataAnnotations) {#>
+        [<#=fkda #>]
+<#   }
+   } #>
         <#=s.Definition #>
 <# } } #>
 <# if(tbl.HasForeignKey) { #>
 
 <#if(IncludeComments != CommentsStyle.None && tbl.Columns.SelectMany(x => x.EntityFk).Any()){#>        // Foreign keys
-
 <# } #>
 <#
 foreach(var entityFk in tbl.Columns.SelectMany(x => x.EntityFk).OrderBy(o => o.Definition))
-{
-    foreach (var fkda in AdditionalForeignKeysDataAnnotations) {#>
-        [<#=fkda #>]
-<# } #>
-<#if(IncludeComments != CommentsStyle.None){#>        /// <summary>
+{ #>
+
+<# if(IncludeComments != CommentsStyle.None){#>        /// <summary>
         /// <#=entityFk.Comments #>
         /// </summary>
-<# } #>
+<# }
+   foreach (var fkda in AdditionalForeignKeysDataAnnotations) {#>
+        [<#=fkda #>]
+<# }
+   if (entityFk.AdditionalDataAnnotations != null) {
+     foreach (var fkda in entityFk.AdditionalDataAnnotations) {#>
+        [<#=fkda #>]
+<#   }
+   } #>
         <#=entityFk.Definition #>
 <# } } #>
 <#


### PR DESCRIPTION
This is the improved way of defining additional annotations for navigation properties. Processing handler is called for each generated property separately and can return fully customizable content, that is later put in front of that property as attributes.

I have also fixed a R# warning about placements of `AdditionalReverseNavigationsDataAnnotations` and `AdditionalForeignKeysDataAnnotations`, as comments were put incorrectly into final output (between annotations and the property definition).