### PR TITLE
Accepting "null" value returned by UpdateColumn

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -2855,7 +2855,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 col = updateColumn(col, table);
 
                 // If PropertyType is empty, return null. Most likely ignoring a column due to legacy (such as OData not supporting spatial types)
-                if(string.IsNullOrEmpty(col.PropertyType))
+                if (col != null && string.IsNullOrEmpty(col.PropertyType))
                     return null;
 
                 return col;


### PR DESCRIPTION
By default the `UpdateColumn()` method returns the same instance it received as a parameter. Of course it's possible to return completely new `Column` instance, but returning `null` will cause a `NullReferenceException` during further processing (inside POCO Core).

I think that returning `null` value is a great way of introduction more sophisticated column filtering. First line of filtering is of course regex `ColumnFilterExclude`, while `UpdateColumn()` can also look at table name or column type.

Probably it was also authors initial idea, that was broken during years of development ;)