### PR TITLE
Skip property name attempts 2 and 3 for primary key table

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -3284,7 +3284,8 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     return name;
                 }
 
-                if(Name == foreignKey.FkTableName){
+                if(Name == foreignKey.FkTableName)
+                {
                     // Attempt 2
                     if (fkName.ToLowerInvariant().EndsWith("id"))
                     {

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -3284,10 +3284,25 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     return name;
                 }
 
-                // Attempt 2
-                if (fkName.ToLowerInvariant().EndsWith("id"))
-                {
-                    col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 2);
+                if(Name == foreignKey.FkTableName){
+                    // Attempt 2
+                    if (fkName.ToLowerInvariant().EndsWith("id"))
+                    {
+                        col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 2);
+                        if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
+                            !ReverseNavigationUniquePropNameClashes.Contains(col))
+                            ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
+
+                        if (!ReverseNavigationUniquePropNameClashes.Contains(col) &&
+                            !ReverseNavigationUniquePropName.Contains(col))
+                        {
+                            ReverseNavigationUniquePropName.Add(col);
+                            return col;
+                        }
+                    }
+
+                    // Attempt 3
+                    col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 3);
                     if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
                         !ReverseNavigationUniquePropNameClashes.Contains(col))
                         ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
@@ -3298,19 +3313,6 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         ReverseNavigationUniquePropName.Add(col);
                         return col;
                     }
-                }
-
-                // Attempt 3
-                col = ForeignKeyName(tableNameHumanCase, foreignKey, fkName, relationship, 3);
-                if (checkForFkNameClashes && ReverseNavigationUniquePropName.Contains(col) &&
-                    !ReverseNavigationUniquePropNameClashes.Contains(col))
-                    ReverseNavigationUniquePropNameClashes.Add(col); // Name clash
-
-                if (!ReverseNavigationUniquePropNameClashes.Contains(col) &&
-                    !ReverseNavigationUniquePropName.Contains(col))
-                {
-                    ReverseNavigationUniquePropName.Add(col);
-                    return col;
                 }
 
                 // Attempt 4


### PR DESCRIPTION
The second and third rename attempts of the GetUniqueColumnName method base their output on the name of the foreign key column.  As foreign key columns are often named after the primary key column or table, this leads to generating a property on the primary object named after itself.

```
public partial class Foo
{
   public int FooId { get; set; }

   // Reverse Navigation
   public virtual Bar Foo { get; set; }  // property is of the type generated for the foreign key table, Bar, but is called Foo (assuming the foreign key column is named 'FooId'
}
```
This pull request compares the current object name for which the property is being generated with the foreign key table name, skipping when the two are not equal 