### PR TITLE
#349 - Eliminate generation of AdditionalContextInterfaceItems in FakeDBContext.

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -542,14 +542,6 @@ foreach (Table tbl in from t in Settings.Tables.Where(t => !t.IsMapping && t.Has
 
             InitializePartial();
 <#}#>        }
-<#foreach (string s in Settings.AdditionalContextInterfaceItems.Where(x => !string.IsNullOrEmpty(x)))
-{ #>
-        public <#=s.TrimEnd(';') #>
-        {
-            throw new System.NotImplementedException();
-        }
-
-<# } #>
 
         public int SaveChangesCount { get; private set; }
         public int SaveChanges()


### PR DESCRIPTION
With the previous implementation, there was no straightforward way to provide an implementation of AdditionalContextInterfaceItems in the FakeDBContext.  Eliminating the generation of these items is consistent with the way the "real" DB Context is emitted and allows for use of MakeClassesPartial set to true and then implementation of these methods in a partial class.