### PR TITLE
Fix to handle line break in table description

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -331,8 +331,14 @@
     {
         if (Settings.IncludeExtendedPropertyComments != CommentsStyle.None && !string.IsNullOrEmpty(t.ExtendedProperty))
         {
+            var lines = t.ExtendedProperty
+                .Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
+                .ToList();
             WriteLine("    ///<summary>");
-            WriteLine("    /// {0}", System.Security.SecurityElement.Escape(t.ExtendedProperty));
+			foreach(var line in lines)
+			{
+				WriteLine("    /// {0}", System.Security.SecurityElement.Escape(line));
+			}
             WriteLine("    ///</summary>");
         }
     };


### PR DESCRIPTION
I added a loop inside the creation of the summary comment because if there were a comment that contains line breaks, the generate code doesn't work.