### PR TITLE
Do not print configuration file if it is blank.

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -543,7 +543,7 @@
         if (Settings.IncludeConnectionSettingComments)
         {
             WriteLine("// The following connection settings were used to generate this file:");
-            if (!string.IsNullOrEmpty(Settings.ConnectionStringName))
+            if (!string.IsNullOrEmpty(Settings.ConnectionStringName) && !string.IsNullOrEmpty(Settings.ConfigFilePath))
             {
                 var solutionPath = Path.GetDirectoryName(GetSolution().FileName) + "\\";
                 WriteLine("//     Configuration file:     \"{0}\"", Settings.ConfigFilePath.Replace(solutionPath, string.Empty));


### PR DESCRIPTION
On v2.34.1, when `Settings.ConnectionString` is set, line 548 of `EF.Reverse.POCO.Core.ttinclude` throws a `NullReferenceException` because `Settings.ConfigFilePath` is null.

It looks like when `InitConnectionString()` is called, because `Settings.ConnectionString` is set it exits early and never calls `GetConnectionString()` which would normally end up setting  `Settings.ConfigFilePath`.

Added an extra check to make sure `Settings.ConfigFilePath` is set before printing it.