### PR TITLE
Declare db sets as IDbSet instead of DbSet in db contexts

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -81,7 +81,7 @@ foreach(var usingStatement in usingsAll.Distinct().OrderBy(x => x)) { #>
 foreach (Table tbl in from t in Settings.Tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase) select t)
 {
 #>
-        System.Data.Entity.DbSet<<#=tbl.NameHumanCaseWithSuffix() #>> <#=Inflector.MakePlural(tbl.NameHumanCase) #> { get; set; }<#if (Settings.IncludeComments != CommentsStyle.None)
+        System.Data.Entity.IDbSet<<#=tbl.NameHumanCaseWithSuffix() #>> <#=Inflector.MakePlural(tbl.NameHumanCase) #> { get; set; }<#if (Settings.IncludeComments != CommentsStyle.None)
 { #> // <#=tbl.Name #>
 <# }
 else
@@ -215,7 +215,7 @@ foreach(var usingStatement in usingsContext.Distinct().OrderBy(x => x)) { #>
 foreach(Table tbl in from t in Settings.Tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase) select t)
 {
 #>
-        public System.Data.Entity.DbSet<<#=tbl.NameHumanCaseWithSuffix()#>> <#=Inflector.MakePlural(tbl.NameHumanCase)#> { get; set; }<#if(Settings.IncludeComments != CommentsStyle.None){#> // <#=tbl.Name#>
+        public System.Data.Entity.IDbSet<<#=tbl.NameHumanCaseWithSuffix()#>> <#=Inflector.MakePlural(tbl.NameHumanCase)#> { get; set; }<#if(Settings.IncludeComments != CommentsStyle.None){#> // <#=tbl.Name#>
 <# } else { #>
 
 <# } #>
@@ -532,7 +532,7 @@ foreach(var usingStatement in usingsContext.Distinct().OrderBy(x => x)) { #>
 foreach (var tbl in from t in Settings.Tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase) select t)
 {
 #>
-        public System.Data.Entity.DbSet<<#=tbl.NameHumanCaseWithSuffix() #>> <#=Inflector.MakePlural(tbl.NameHumanCase) #> { get; set; }
+        public System.Data.Entity.IDbSet<<#=tbl.NameHumanCaseWithSuffix() #>> <#=Inflector.MakePlural(tbl.NameHumanCase) #> { get; set; }
 <# } #>
 
         public Fake<#=Settings.DbContextName #>()


### PR DESCRIPTION
This reduces the work to setup mocking when using a framework such as NSubstitute.