### PR TITLE
Adding Settings.UseDefaultConstructor.

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -18,6 +18,7 @@
     //Settings.DbContextInterfaceName = "IMyDbContext"; // Defaults to "I" + DbContextName or set string empty to not implement any interface.
     Settings.DbContextInterfaceBaseClasses = "System.IDisposable";    // Specify what the base classes are for your database context interface
     Settings.DbContextBaseClass = "System.Data.Entity.DbContext";   // Specify what the base class is for your DbContext. For ASP.NET Identity use "IdentityDbContext<ApplicationUser>"
+    Settings.UseDefaultConstructor = true; // If true (the default value), the DbContext will have a default (parameterless) constructor defined, if false then no parameterless constructor will be defined.
     //Settings.DefaultConstructorArgument = "EnvironmentConnectionStrings.MyDbContext"; //defaults to "Name=" + ConnectionStringName
     Settings.ConfigurationClassName = "Configuration"; // Configuration, Mapping, Map, etc. This is appended to the Poco class name to configure the mappings.
     Settings.FilenameSearchOrder = new[] { "app.config", "web.config" }; // Add more here if required. The config files are searched for in the local project first, then the whole solution second.

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -67,6 +67,7 @@
         public static string DbContextInterfaceBaseClasses;
         public static string DbContextBaseClass;
 
+        public static bool UseDefaultConstructor = true;
         private static string _defaultConstructorArgument;
         public static string DefaultConstructorArgument
         {

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -237,8 +237,8 @@ foreach(Table tbl in from t in Settings.Tables.Where(t => !t.IsMapping && t.HasP
 <#if(Settings.MakeClassesPartial) {#>            InitializePartial();
 <#}#>
         }
-<#}#>
 
+<#}#>
         <# if(Settings.MakeClassesInternal) { #>internal<# } else { #>public<# } #> <#=Settings.DbContextName#>(string connectionString)
             : base(connectionString)
         {

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -230,12 +230,14 @@ foreach(Table tbl in from t in Settings.Tables.Where(t => !t.IsMapping && t.HasP
 <#}#>
         }
 
+<#if(Settings.UseDefaultConstructor) {#>
         public <#=Settings.DbContextName#>()
             : base(<#=Settings.DefaultConstructorArgument#>)
         {
 <#if(Settings.MakeClassesPartial) {#>            InitializePartial();
 <#}#>
         }
+<#}#>
 
         <# if(Settings.MakeClassesInternal) { #>internal<# } else { #>public<# } #> <#=Settings.DbContextName#>(string connectionString)
             : base(connectionString)


### PR DESCRIPTION
The EF6 EDMX designer had an option to exclude the default DbContext constructor - which makes sense when you don't want the design-time connection-string or connection-string-name to be in production code - or if you're using the DbContext in an application where named connection-strings aren't available (e.g. DNX?)