### PR TITLE
Adding ForeignKey.AccessModifier

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -414,6 +414,9 @@
         // if (fk.PkTableName.EndsWith("Type"))
         //    fk.IncludeReverseNavigation = false;
 
+        // You can also change the access modifier of the foreign-key's navigation property:
+        // if(fk.PkTableName == "Categories") fk.AccessModifier = "internal";
+
         return fk;
     };
 

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -335,10 +335,10 @@
                 .Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
                 .ToList();
             WriteLine("    ///<summary>");
-			foreach(var line in lines)
-			{
-				WriteLine("    /// {0}", System.Security.SecurityElement.Escape(line));
-			}
+            foreach(var line in lines)
+            {
+                WriteLine("    /// {0}", System.Security.SecurityElement.Escape(line));
+            }
             WriteLine("    ///</summary>");
         }
     };

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -3727,7 +3727,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 case Relationship.ManyToMany:
                     break;
             }
-            string accessModifier = fks.FirstOrDefault()?.AccessModifier ?? "public";
+            string accessModifier = fks?.FirstOrDefault()?.AccessModifier ?? "public";
             switch (relationship)
             {
                 case Relationship.OneToOne:

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -3463,6 +3463,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
         public bool IsNotEnforced { get; private set; }
 
         // User settable via ForeignKeyFilter callback
+        public string AccessModifier { get; set; }
         public bool IncludeReverseNavigation { get; set; }
         public bool IncludeRequiredAttribute { get; set; }
 
@@ -3726,6 +3727,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 case Relationship.ManyToMany:
                     break;
             }
+            string accessModifier = fks.FirstOrDefault()?.AccessModifier ?? "public";
             switch (relationship)
             {
                 case Relationship.OneToOne:
@@ -3733,7 +3735,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         new PropertyAndComments()
                         {
                             AdditionalDataAnnotations = Settings.ForeignKeyAnnotationsProcessing(fkTable, this, propName),
-                            Definition = string.Format("public {0}{1} {2} {{ get; set; }}{3}", GetLazyLoadingMarker(), fkTable.NameHumanCaseWithSuffix(), propName, Settings.IncludeComments != CommentsStyle.None ? " // " + constraint : string.Empty),
+                            Definition = string.Format("{0} {1}{2} {3} {{ get; set; }}{4}", accessModifier, GetLazyLoadingMarker(), fkTable.NameHumanCaseWithSuffix(), propName, Settings.IncludeComments != CommentsStyle.None ? " // " + constraint : string.Empty),
                             Comments = string.Format("Parent (One-to-One) {0} pointed by [{1}].{2} ({3})", NameHumanCaseWithSuffix(), fkTable.Name, fkNames, fks.First().ConstraintName)
                         }
                     );
@@ -3744,7 +3746,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         new PropertyAndComments()
                         {
                             AdditionalDataAnnotations = Settings.ForeignKeyAnnotationsProcessing(fkTable, this, propName),
-                            Definition = string.Format("public {0}{1} {2} {{ get; set; }}{3}", GetLazyLoadingMarker(), fkTable.NameHumanCaseWithSuffix(), propName, Settings.IncludeComments != CommentsStyle.None ? " // " + constraint : string.Empty),
+                            Definition = string.Format("{0} {1}{2} {3} {{ get; set; }}{4}", accessModifier, GetLazyLoadingMarker(), fkTable.NameHumanCaseWithSuffix(), propName, Settings.IncludeComments != CommentsStyle.None ? " // " + constraint : string.Empty),
                             Comments = string.Format("Parent {0} pointed by [{1}].{2} ({3})", NameHumanCaseWithSuffix(), fkTable.Name, fkNames, fks.First().ConstraintName)
                         }
                     );
@@ -3758,7 +3760,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         new PropertyAndComments()
                         {
                             AdditionalDataAnnotations = Settings.ForeignKeyAnnotationsProcessing(fkTable, this, propName),
-                            Definition = string.Format("public {0}{1}<{2}> {3} {{ get; set; }}{4}{5}", GetLazyLoadingMarker(), Settings.CollectionInterfaceType, fkTable.NameHumanCaseWithSuffix(), propName, initialization1, Settings.IncludeComments != CommentsStyle.None ? " // " + constraint : string.Empty),
+                            Definition = string.Format("{0} {1}{2}<{3}> {4} {{ get; set; }}{5}{6}", accessModifier, GetLazyLoadingMarker(), Settings.CollectionInterfaceType, fkTable.NameHumanCaseWithSuffix(), propName, initialization1, Settings.IncludeComments != CommentsStyle.None ? " // " + constraint : string.Empty),
                             Comments = string.Format("Child {0} where [{1}].{2} point to this entity ({3})", Inflector.MakePlural(fkTable.NameHumanCase), fkTable.Name, fkNames, fks.First().ConstraintName)
                         }
                     );
@@ -3773,7 +3775,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         new PropertyAndComments()
                         {
                             AdditionalDataAnnotations = Settings.ForeignKeyAnnotationsProcessing(fkTable, this, propName),
-                            Definition = string.Format("public {0}{1}<{2}> {3} {{ get; set; }}{4}{5}", GetLazyLoadingMarker(), Settings.CollectionInterfaceType, fkTable.NameHumanCaseWithSuffix(), propName, initialization2, Settings.IncludeComments != CommentsStyle.None ? " // Many to many mapping" : string.Empty),
+                            Definition = string.Format("{0} {1}{2}<{3}> {4} {{ get; set; }}{5}{6}", accessModifier, GetLazyLoadingMarker(), Settings.CollectionInterfaceType, fkTable.NameHumanCaseWithSuffix(), propName, initialization2, Settings.IncludeComments != CommentsStyle.None ? " // Many to many mapping" : string.Empty),
                             Comments = string.Format("Child {0} (Many-to-Many) mapped by table [{1}]", Inflector.MakePlural(fkTable.NameHumanCase), mappingTable == null ? string.Empty : mappingTable.Name)
                         }
                     );

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -377,8 +377,8 @@
     }
 
     public DTE GetDTE()
-	{
-		var serviceProvider = GetServiceProvider();
+    {
+        var serviceProvider = GetServiceProvider();
 
         var dte = (DTE)serviceProvider.GetService(typeof(DTE));
         if(dte == null)
@@ -1932,7 +1932,7 @@ SELECT  FK.name AS FK_Table,
         k.constraint_column_id AS ORDINAL_POSITION,
         CASE WHEN f.delete_referential_action = 1 THEN 1 ELSE 0 END as CascadeOnDelete,
         f.is_disabled AS IsNotEnforced
-INTO	#SynonymFkDetails
+INTO    #SynonymFkDetails
 FROM    sys.objects AS PK
         INNER JOIN sys.foreign_keys AS f
             INNER JOIN sys.foreign_key_columns AS k
@@ -1999,7 +1999,7 @@ DECLARE @synonmymDatabaseName sysname = (SELECT TOP (1) DatabaseName FROM #Synon
 DECLARE @synonymFkDetailsQueryWithDb nvarchar(max)
 WHILE (@synonmymDatabaseName IS NOT NULL)
 BEGIN
-	SET @synonymFkDetailsQueryWithDb = 'USE [' + @synonmymDatabaseName + '] ' + @synonymFkDetailsQuery
+    SET @synonymFkDetailsQueryWithDb = 'USE [' + @synonmymDatabaseName + '] ' + @synonymFkDetailsQuery
     EXEC sp_executesql @stmt=@synonymFkDetailsQueryWithDb
     DELETE FROM #SynonymTargets WHERE DatabaseName = @synonmymDatabaseName
     SET @synonmymDatabaseName = (SELECT TOP (1) DatabaseName FROM #SynonymTargets)
@@ -2255,7 +2255,7 @@ SELECT  TOP (0) R.SPECIFIC_SCHEMA,
         ISNULL(P.NUMERIC_SCALE, 0) AS NUMERIC_SCALE,
         ISNULL(P.DATETIME_PRECISION, 0) AS DATETIME_PRECISION,
         P.USER_DEFINED_TYPE_SCHEMA + '.' + P.USER_DEFINED_TYPE_NAME AS USER_DEFINED_TYPE
-INTO	#SynonymStoredProcedureDetails
+INTO    #SynonymStoredProcedureDetails
 FROM    INFORMATION_SCHEMA.ROUTINES R
         LEFT OUTER JOIN INFORMATION_SCHEMA.PARAMETERS P
             ON P.SPECIFIC_SCHEMA = R.SPECIFIC_SCHEMA
@@ -2295,7 +2295,7 @@ ORDER BY PARSENAME(sn.base_object_name, 3)
 DECLARE @synonymStoredProcedureDetailsQuery nvarchar(max) =
 '
 INSERT INTO #SynonymStoredProcedureDetails (SPECIFIC_SCHEMA, SPECIFIC_NAME, ROUTINE_TYPE, ORDINAL_POSITION, PARAMETER_MODE, PARAMETER_NAME, DATA_TYPE
-											, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, USER_DEFINED_TYPE)
+                                            , CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, USER_DEFINED_TYPE)
 SELECT  R.SPECIFIC_SCHEMA,
         R.SPECIFIC_NAME,
         R.ROUTINE_TYPE,
@@ -2364,7 +2364,7 @@ DECLARE @synonmymDatabaseName sysname = (SELECT TOP (1) DatabaseName FROM #Synon
 DECLARE @synonymStoredProcedureDetailsQueryWithDb nvarchar(max)
 WHILE (@synonmymDatabaseName IS NOT NULL)
 BEGIN
-	SET @synonymStoredProcedureDetailsQueryWithDb = 'USE [' + @synonmymDatabaseName + '] ' + @synonymStoredProcedureDetailsQuery
+    SET @synonymStoredProcedureDetailsQueryWithDb = 'USE [' + @synonmymDatabaseName + '] ' + @synonymStoredProcedureDetailsQuery
     EXEC sp_executesql @stmt=@synonymStoredProcedureDetailsQueryWithDb
     DELETE FROM #SynonymTargets WHERE DatabaseName = @synonmymDatabaseName
     SET @synonmymDatabaseName = (SELECT TOP (1) DatabaseName FROM #SynonymTargets)
@@ -2377,7 +2377,7 @@ SET NOCOUNT OFF;
 UNION
 -- Synonyms
 SELECT SPECIFIC_SCHEMA, SPECIFIC_NAME, ROUTINE_TYPE, ORDINAL_POSITION, PARAMETER_MODE, PARAMETER_NAME, DATA_TYPE
-	, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, USER_DEFINED_TYPE FROM #SynonymStoredProcedureDetails";
+    , CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION, USER_DEFINED_TYPE FROM #SynonymStoredProcedureDetails";
 
         private const string IndexSQL = @"
 SELECT  SCHEMA_NAME(t.schema_id) AS TableSchema,


### PR DESCRIPTION
This PR extends `class ForeignKey` with a new property `string AccessModifier` which can be set in `ForeignKeyFilter` instead of making them all `public`. It always falls-back to `public` if not set.

My editor also corrected some leading-tabs in the files that I've added as a second commit. The relevant changes are only in the first commit: fb8a7f6.