### PR TITLE
Hybrid annotations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+# All files
+[*]
+indent_style = space
+indent_size = 4

--- a/EF.Reverse.POCO.Generator.sln
+++ b/EF.Reverse.POCO.Generator.sln
@@ -15,6 +15,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework Reverse POC
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{69BEE662-119F-459F-B4B4-8C14F725258C}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/EntityFramework.Reverse.POCO.Generator/Database NorthwindSqlCe40.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database NorthwindSqlCe40.tt
@@ -331,7 +331,7 @@
             WriteLine("        ///</summary>");
             commentWritten = true;
         }
-        if (Settings.UseDataAnnotations)
+        if (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent)
         {
             if(c.Ordinal > 1 && !commentWritten)
                 WriteLine(string.Empty);    // Leave a blank line before the next property

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -75,6 +75,7 @@
         { "emailaddress",    "EmailAddress" },
         { "creditcard",      "CreditCard" },
         { "url",             "Url" },
+        { "fax",             "Phone" },
         { "phone",           "Phone" },
         { "phonenumber",     "Phone" },
         { "mobile",          "Phone" },
@@ -82,7 +83,24 @@
         { "telephone",       "Phone" },
         { "telephonenumber", "Phone" },
         { "password",        "DataType(DataType.Password)" },
-        { "username",        "DataType(DataType.Text)" }
+        { "username",        "DataType(DataType.Text)" },
+        { "postcode",        "DataType(DataType.PostalCode)" },
+        { "postalcode",      "DataType(DataType.PostalCode)" },
+        { "zip",             "DataType(DataType.PostalCode)" },
+        { "zipcode",         "DataType(DataType.PostalCode)" }
+    };
+    Settings.ColumnTypeToDataAnnotation = new Dictionary<string, string>
+    {
+        // This is used when UseDataAnnotations == true or UseDataAnnotationsWithFluent == true;
+        // It is used to set a data annotation on a column based on the columns's MS SQL type.
+        // Make sure the column name is lowercase in the following array, regardless of how it is in the database
+        // Column name       DataAnnotation to add
+        { "date",            "DataType(DataType.Date)" },
+        { "datetime",        "DataType(DataType.DateTime)" },
+        { "datetime2",       "DataType(DataType.DateTime)" },
+        { "datetimeoffset",  "DataType(DataType.DateTime)" },
+        { "smallmoney",      "DataType(DataType.Currency)" },
+        { "money",           "DataType(DataType.Currency)" }
     };
 
     // Migrations *************************************************************************************************************************

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -67,7 +67,7 @@
     };
     Settings.ColumnNameToDataAnnotation = new Dictionary<string, string>
     {
-        // This is used when UseDataAnnotations = true;
+        // This is used when UseDataAnnotations == true or UseDataAnnotationsWithFluent == true;
         // It is used to set a data annotation on a column based on the columns name.
         // Make sure the column name is lowercase in the following array, regardless of how it is in the database
         // Column name       DataAnnotation to add
@@ -421,7 +421,7 @@
             WriteLine("        ///</summary>");
             commentWritten = true;
         }
-        if (Settings.UseDataAnnotations)
+        if (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent)
         {
             if(c.Ordinal > 1 && !commentWritten)
                 WriteLine(string.Empty);    // Leave a blank line before the next property

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -29,6 +29,7 @@
     Settings.UseMappingTables = true; // If true, mapping will be used and no mapping tables will be generated. If false, all tables will be generated.
     Settings.UsePascalCase = true;    // This will rename the generated C# tables & properties to use PascalCase. If false table & property names will be left alone.
     Settings.UseDataAnnotations = false; // If true, will add data annotations to the poco classes.
+    Settings.UseDataAnnotationsWithFluent = false; // If true, then non-Entity Framework-specific DataAnnotations (like [Required] and [StringLength]) will be applied to Entities even if UseDataAnnotations is false.
     Settings.UsePropertyInitializers = false; // Removes POCO constructor and instead uses C# 6 property initialisers to set defaults
     Settings.UseLazyLoading = true; // Marks all navigation properties as virtual or not, to support or disable EF Lazy Loading feature
     Settings.IncludeComments = CommentsStyle.AtEndOfField; // Adds comments to the generated code

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -133,6 +133,7 @@
         public static bool AutomaticMigrationDataLossAllowed;
         public static List<EnumDefinition> EnumDefinitions = new List<EnumDefinition>();
         public static Dictionary<string, string> ColumnNameToDataAnnotation;
+        public static Dictionary<string, string> ColumnTypeToDataAnnotation;
         public static bool IncludeCodeGeneratedAttribute;
         public static Tables Tables;
         public static List<StoredProcedure> StoredProcs;
@@ -1184,9 +1185,14 @@
             if (IsPrimaryKey && Settings.UseDataAnnotations)
                 DataAnnotations.Add("Key");
 
-            string value;
-            if(Settings.ColumnNameToDataAnnotation.TryGetValue(NameHumanCase.ToLowerInvariant(), out value))
-                DataAnnotations.Add(value);
+            if (Settings.ColumnNameToDataAnnotation.TryGetValue(NameHumanCase.ToLowerInvariant(), out string valueFromName))
+            {
+                DataAnnotations.Add(valueFromName);
+            }
+            else if (Settings.ColumnTypeToDataAnnotation.TryGetValue(SqlPropertyType.ToLowerInvariant(), out string valueFromType))
+            {
+                DataAnnotations.Add(valueFromType);
+            }
 
             DataAnnotations.Add(string.Format("Display(Name = \"{0}\")", DisplayName));
         }
@@ -3140,8 +3146,8 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 if(foreignKey.IncludeReverseNavigation)
                 {
                     pkTable.AddReverseNavigation(relationship, pkTableHumanCase, fkTable, fkPropName, string.Format("{0}.{1}", fkTable.Name, foreignKey.ConstraintName), foreignKeys);
+                }
             }
-        }
         }
 
         public override void IdentifyForeignKeys(List<ForeignKey> fkList, Tables tables)

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -1181,10 +1181,7 @@
             if(!string.IsNullOrEmpty(config))
                 Config = string.Format("Property(x => x.{0}){1};", NameHumanCase, config);
 
-            if (!Settings.UseDataAnnotations)
-                return; // Only data annotations below this point
-
-            if (IsPrimaryKey)
+            if (IsPrimaryKey && Settings.UseDataAnnotations)
                 DataAnnotations.Add("Key");
 
             string value;
@@ -3135,13 +3132,16 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
 
                 if (!Settings.UseDataAnnotations)
                 {
-                    fkCol.col.ConfigFk.Add(string.Format("{0};{1}", GetRelationship(relationship, fkCol.col, pkCol, pkPropName, fkPropName, manyToManyMapping, mapKey, foreignKey.CascadeOnDelete, foreignKey.IncludeReverseNavigation, foreignKey.IsNotEnforced),
-                        Settings.IncludeComments != CommentsStyle.None ? " // " + foreignKey.ConstraintName : string.Empty));
+                    string rel = GetRelationship(relationship, fkCol.col, pkCol, pkPropName, fkPropName, manyToManyMapping, mapKey, foreignKey.CascadeOnDelete, foreignKey.IncludeReverseNavigation, foreignKey.IsNotEnforced);
+                    string com = Settings.IncludeComments != CommentsStyle.None ? " // " + foreignKey.ConstraintName : string.Empty;
+                    fkCol.col.ConfigFk.Add(string.Format("{0};{1}", rel, com));
                 }
 
                 if(foreignKey.IncludeReverseNavigation)
+                {
                     pkTable.AddReverseNavigation(relationship, pkTableHumanCase, fkTable, fkPropName, string.Format("{0}.{1}", fkTable.Name, foreignKey.ConstraintName), foreignKeys);
             }
+        }
         }
 
         public override void IdentifyForeignKeys(List<ForeignKey> fkList, Tables tables)

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -80,6 +80,7 @@
         public static string CollectionType = "System.Collections.Generic.List";
         public static bool NullableShortHand;
         public static bool UseDataAnnotations;
+        public static bool UseDataAnnotationsWithFluent;
         public static bool MakeClassesPartial;
         public static bool MakeClassesInternal;
         public static bool MakeDbContextInterfacePartial;
@@ -690,7 +691,7 @@
 
                 foreach (var t in tables)
                 {
-                    if(Settings.UseDataAnnotations)
+                    if(Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent)
                         t.SetupDataAnnotations();
                     t.Suffix = Settings.TableSuffix;
                 }
@@ -1091,13 +1092,16 @@
             }
             else
             {
-                if (Settings.UseDataAnnotations)
+                if (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent)
                 {
                     if(!IsComputed())
                         DataAnnotations.Add("Required");
                 }
-                else
+                
+                if (!Settings.UseDataAnnotations)
+                {
                     sb.Append(".IsRequired()");
+                }
             }
 
             if (IsFixedLength || IsRowVersion)
@@ -1116,28 +1120,38 @@
             {
                 var doNotSpecifySize = (Settings.IsSqlCe && MaxLength > 4000); // Issue #179
 
-                if (Settings.UseDataAnnotations)
+                if (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent)
                 {
                     DataAnnotations.Add(doNotSpecifySize ? "MaxLength" : string.Format("MaxLength({0})", MaxLength));
 
                     if (PropertyType.Equals("string", StringComparison.InvariantCultureIgnoreCase))
                         DataAnnotations.Add(string.Format("StringLength({0})", MaxLength));
                 }
-                else
+                
+                if (!Settings.UseDataAnnotations)
                 {
                     if (doNotSpecifySize)
+                    {
                         sb.Append(".HasMaxLength(null)");
+                    }
                     else
+                    {
                         sb.AppendFormat(".HasMaxLength({0})", MaxLength);
+                    }
                 }
             }
 
             if (IsMaxLength)
             {
-                if (Settings.UseDataAnnotations)
+                if (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent)
+                {
                     DataAnnotations.Add("MaxLength");
-                else
+                }
+
+                if (!Settings.UseDataAnnotations)
+                {
                     sb.Append(".IsMaxLength()");
+                }
             }
 
             if ((Precision > 0 || Scale > 0) && PropertyType == "decimal")

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -19,8 +19,10 @@ fileManager.StartHeader();
 
 <#if (Settings.ElementsToGenerate.HasFlag(Elements.Poco) || Settings.ElementsToGenerate.HasFlag(Elements.PocoConfiguration))
 {
-    if (Settings.UseDataAnnotations) {#>
+    if (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent) { #>
 using System.ComponentModel.DataAnnotations;
+<# }
+    if (Settings.UseDataAnnotations) {#>
 using System.ComponentModel.DataAnnotations.Schema;
 <#  }
 }


### PR DESCRIPTION
See issue #434 

Adds `Settings.UseDataAnnotationsWithFluent` which causes a select subset of annotations to be applied to entity class properties which may be useful outside of Entity Framework.