### PR TITLE
Use `AllowEmptyStrings = true` on required string properties to prevent excessive validation errors.

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -966,6 +966,7 @@
         public string ExtendedProperty;
         public string SummaryComments;
         public string UniqueIndexName;
+        public bool AllowEmptyStrings = true;
 
         public bool IsIdentity;
         public bool IsNullable;
@@ -1112,7 +1113,7 @@
             {
                 if (!IsComputed() && (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent))
                 {
-                    if (PropertyType.Equals("string", StringComparison.InvariantCultureIgnoreCase))
+                    if (PropertyType.Equals("string", StringComparison.InvariantCultureIgnoreCase) && this.AllowEmptyStrings)
                     {
                         DataAnnotations.Add("Required(AllowEmptyStrings = true)");
                     }

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -1110,10 +1110,16 @@
             }
             else
             {
-                if (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent)
+                if (!IsComputed() && (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent))
                 {
-                    if(!IsComputed())
+                    if (PropertyType.Equals("string", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        DataAnnotations.Add("Required(AllowEmptyStrings = true)");
+                    }
+                    else
+                    {
                         DataAnnotations.Add("Required");
+                    }
                 }
 
                 if (!Settings.UseDataAnnotations)


### PR DESCRIPTION
If `[Required]` is set on a string property, then EF's entity validation code (invoked on `.SaveChanges()` will complain if the property is an empty, but not null, string. This was a bug I introduced in my hybrid-annotations code without realizing it (as the Fluent `.IsRequired()` method does not add a non-empty check, only non-null).

This PR adds `AlowEmptyStrings = true` for string columns with `[Required]`. It also adds a property to `class Column` so customization code in the T4 can opt-in to require non-empty, non-null strings.