### PR TITLE
Temporal tables and generated cols

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -966,6 +966,7 @@
         public string ExtendedProperty;
         public string SummaryComments;
         public string UniqueIndexName;
+        public bool AllowEmptyStrings = true;
 
         public bool IsIdentity;
         public bool IsNullable;
@@ -1112,7 +1113,7 @@
             {
                 if (!IsComputed() && (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent))
                 {
-                    if (PropertyType.Equals("string", StringComparison.InvariantCultureIgnoreCase))
+                    if (PropertyType.Equals("string", StringComparison.InvariantCultureIgnoreCase) && this.AllowEmptyStrings)
                     {
                         DataAnnotations.Add("Required(AllowEmptyStrings = true)");
                     }

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -1698,93 +1698,161 @@ IF OBJECT_ID('tempdb..#Columns')     IS NOT NULL DROP TABLE #Columns;
 IF OBJECT_ID('tempdb..#PrimaryKeys') IS NOT NULL DROP TABLE #PrimaryKeys;
 IF OBJECT_ID('tempdb..#ForeignKeys') IS NOT NULL DROP TABLE #ForeignKeys;
 
-SELECT  C.TABLE_SCHEMA,
-        C.TABLE_NAME,
-        C.COLUMN_NAME,
-        C.ORDINAL_POSITION,
-        C.COLUMN_DEFAULT,
-        C.IS_NULLABLE,
-        C.DATA_TYPE,
-        C.CHARACTER_MAXIMUM_LENGTH,
-        C.NUMERIC_PRECISION,
-        C.NUMERIC_SCALE,
-        C.DATETIME_PRECISION
-INTO    #Columns
-FROM    INFORMATION_SCHEMA.COLUMNS C
-WHERE   C.TABLE_NAME NOT IN ('EdmMetadata', '__MigrationHistory', '__RefactorLog')
-        AND C.TABLE_NAME NOT LIKE 'sysdiagram%';
+SELECT
+	c.TABLE_SCHEMA,
+	c.TABLE_NAME,
+	c.COLUMN_NAME,
+	c.ORDINAL_POSITION,
+	c.COLUMN_DEFAULT,
+	sc.is_nullable,
+	c.DATA_TYPE,
+	c.CHARACTER_MAXIMUM_LENGTH,
+	c.NUMERIC_PRECISION,
+	c.NUMERIC_SCALE,
+	c.DATETIME_PRECISION,
+
+	ss.schema_id,
+	st.object_id AS table_object_id,
+	sv.object_id AS view_object_id,
+	
+	sc.is_identity,
+	sc.is_rowguidcol,
+	sc.is_computed, -- Computed columns are read-only, do not confuse it with a column with a DEFAULT expression (which can be re-assigned). See the IsStoreGenerated attribute.
+	CONVERT( tinyint, [sc].[generated_always_type] ) AS generated_always_type -- SQL Server 2016 (13.x) or later. 0 = Not generated, 1 = AS_ROW_START, 2 = AS_ROW_END
+	
+INTO
+	#Columns
+FROM
+	INFORMATION_SCHEMA.COLUMNS c
+
+	INNER JOIN sys.schemas AS ss ON c.TABLE_SCHEMA = ss.[name]
+	LEFT OUTER JOIN sys.tables AS st ON st.schema_id = ss.schema_id AND st.[name] = c.TABLE_NAME
+	LEFT OUTER JOIN sys.views AS sv ON sv.schema_id = ss.schema_id AND sv.[name] = c.TABLE_NAME
+	INNER JOIN sys.all_columns AS sc ON sc.object_id = COALESCE( st.object_id, sv.object_id ) AND c.COLUMN_NAME = sc.[name]
+
+WHERE
+	C.TABLE_NAME NOT IN ('EdmMetadata', '__MigrationHistory', '__RefactorLog', 'sysdiagrams')
+
 
 CREATE NONCLUSTERED INDEX IX_EfPoco_Columns
 ON dbo.#Columns (TABLE_NAME)
-INCLUDE (TABLE_SCHEMA,COLUMN_NAME,ORDINAL_POSITION,COLUMN_DEFAULT,IS_NULLABLE,DATA_TYPE,CHARACTER_MAXIMUM_LENGTH,NUMERIC_PRECISION,NUMERIC_SCALE,DATETIME_PRECISION);
+	INCLUDE (
+		TABLE_SCHEMA,COLUMN_NAME,ORDINAL_POSITION,COLUMN_DEFAULT,IS_NULLABLE,DATA_TYPE,CHARACTER_MAXIMUM_LENGTH,NUMERIC_PRECISION,NUMERIC_SCALE,DATETIME_PRECISION,
+		schema_id, table_object_id, view_object_id,
+		is_identity,is_rowguidcol,is_computed,generated_always_type
+	);
+	
+--SELECT * FROM #Columns;
 
-SELECT  u.TABLE_SCHEMA,
+-----------
+SELECT
+	u.TABLE_SCHEMA,
         u.TABLE_NAME,
         u.COLUMN_NAME,
         u.ORDINAL_POSITION
-INTO    #PrimaryKeys
-FROM    INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
-        INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-            ON u.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = tc.CONSTRAINT_SCHEMA COLLATE DATABASE_DEFAULT
-               AND u.TABLE_NAME = tc.TABLE_NAME
-               AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
-WHERE   CONSTRAINT_TYPE = 'PRIMARY KEY';
+INTO
+	#PrimaryKeys
+FROM
+	INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+	INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON
+		u.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = tc.CONSTRAINT_SCHEMA COLLATE DATABASE_DEFAULT
+		AND
+		u.TABLE_NAME = tc.TABLE_NAME
+		AND
+		u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+WHERE
+	CONSTRAINT_TYPE = 'PRIMARY KEY';
 
 SELECT DISTINCT
         u.TABLE_SCHEMA,
         u.TABLE_NAME,
         u.COLUMN_NAME
-INTO    #ForeignKeys
-FROM    INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
-        INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-            ON u.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = tc.CONSTRAINT_SCHEMA COLLATE DATABASE_DEFAULT
-               AND u.TABLE_NAME = tc.TABLE_NAME
-               AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
-WHERE   CONSTRAINT_TYPE = 'FOREIGN KEY';
+INTO
+	#ForeignKeys
+FROM
+	INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+	INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON
+		u.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = tc.CONSTRAINT_SCHEMA COLLATE DATABASE_DEFAULT
+		AND
+		u.TABLE_NAME = tc.TABLE_NAME
+		AND
+		u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+WHERE
+	CONSTRAINT_TYPE = 'FOREIGN KEY';
 
-SELECT  c.TABLE_SCHEMA AS SchemaName,
+--------------------------
+
+SELECT
+	c.TABLE_SCHEMA AS SchemaName,
         c.TABLE_NAME AS TableName,
         t.TABLE_TYPE AS TableType,
+	CONVERT( tinyint, ISNULL( tt.temporal_type, 0 ) ) AS TableTemporalType,
+
         c.ORDINAL_POSITION AS Ordinal,
         c.COLUMN_NAME AS ColumnName,
-        CAST(CASE WHEN IS_NULLABLE = 'YES' THEN 1
-                  ELSE 0
-             END AS BIT) AS IsNullable,
+	c.is_nullable AS IsNullable,
         DATA_TYPE AS TypeName,
-        ISNULL(CHARACTER_MAXIMUM_LENGTH, 0) AS MaxLength,
-        CAST(ISNULL(NUMERIC_PRECISION, 0) AS INT) AS Precision,
+	ISNULL(CHARACTER_MAXIMUM_LENGTH, 0) AS [MaxLength],
+	CAST(ISNULL(NUMERIC_PRECISION, 0) AS INT) AS [Precision],
         ISNULL(COLUMN_DEFAULT, '') AS [Default],
         CAST(ISNULL(DATETIME_PRECISION, 0) AS INT) AS DateTimePrecision,
         ISNULL(NUMERIC_SCALE, 0) AS Scale,
-        CAST(COLUMNPROPERTY(OBJECT_ID(QUOTENAME(c.TABLE_SCHEMA) + '.' + QUOTENAME(c.TABLE_NAME)), c.COLUMN_NAME, 'IsIdentity') AS BIT) AS IsIdentity,
-        CAST(CASE WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(c.TABLE_SCHEMA) + '.' + QUOTENAME(c.TABLE_NAME)), c.COLUMN_NAME, 'IsIdentity') = 1 THEN 1
-                  WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(c.TABLE_SCHEMA) + '.' + QUOTENAME(c.TABLE_NAME)), c.COLUMN_NAME, 'IsComputed') = 1 THEN 1
-                  WHEN DATA_TYPE = 'TIMESTAMP' THEN 1
-                  WHEN DATA_TYPE = 'UNIQUEIDENTIFIER'
-                       AND LOWER(ISNULL(COLUMN_DEFAULT, '')) LIKE '%newsequentialid%' THEN 1
-                  ELSE 0
-             END AS BIT) AS IsStoreGenerated,
-        CAST(CASE WHEN pk.ORDINAL_POSITION IS NULL THEN 0
-                  ELSE 1
-             END AS BIT) AS PrimaryKey,
+
+	c.is_identity AS IsIdentity,
+	c.is_rowguidcol AS IsRowGuid,
+	c.is_computed AS IsComputed,
+	c.generated_always_type AS GeneratedAlwaysType,
+
+	CONVERT( bit,
+		CASE WHEN
+			c.is_identity = 1 OR
+			c.is_rowguidcol = 1 OR
+			c.is_computed = 1 OR
+			c.generated_always_type <> 0 OR
+			c.DATA_TYPE IN ( 'rowversion', 'timestamp' ) OR
+			( c.DATA_TYPE = 'uniqueidentifier' AND c.COLUMN_DEFAULT LIKE '%newsequentialid%' )
+			THEN 1
+		ELSE
+			0
+		END
+	) AS IsStoreGenerated,
+	
+	CONVERT( bit, ISNULL( pk.ORDINAL_POSITION, 0 ) ) AS PrimaryKey,
         ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
-        CAST(CASE WHEN fk.COLUMN_NAME IS NULL THEN 0
-                  ELSE 1
-             END AS BIT) AS IsForeignKey
-FROM    #Columns c
-        LEFT OUTER JOIN #PrimaryKeys pk
-            ON c.TABLE_SCHEMA = pk.TABLE_SCHEMA
-               AND c.TABLE_NAME = pk.TABLE_NAME
-               AND c.COLUMN_NAME = pk.COLUMN_NAME
-        LEFT OUTER JOIN #ForeignKeys fk
-            ON c.TABLE_SCHEMA = fk.TABLE_SCHEMA
-               AND c.TABLE_NAME = fk.TABLE_NAME
-               AND c.COLUMN_NAME = fk.COLUMN_NAME
-        INNER JOIN INFORMATION_SCHEMA.TABLES t
-            ON c.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = t.TABLE_SCHEMA COLLATE DATABASE_DEFAULT
-               AND c.TABLE_NAME COLLATE DATABASE_DEFAULT = t.TABLE_NAME COLLATE DATABASE_DEFAULT
-WHERE   c.TABLE_NAME NOT IN ('EdmMetadata', '__MigrationHistory', '__RefactorLog')
-        AND c.TABLE_NAME NOT LIKE 'sysdiagram%' ";
+	CONVERT( bit, CASE WHEN fk.COLUMN_NAME IS NOT NULL THEN 1 ELSE 0 END ) AS IsForeignKey
+
+FROM
+	
+	#Columns c
+	
+	LEFT OUTER JOIN #PrimaryKeys pk ON
+		c.TABLE_SCHEMA = pk.TABLE_SCHEMA AND
+		c.TABLE_NAME   = pk.TABLE_NAME AND
+		c.COLUMN_NAME  = pk.COLUMN_NAME
+
+	LEFT OUTER JOIN #ForeignKeys fk ON
+		c.TABLE_SCHEMA = fk.TABLE_SCHEMA AND
+		c.TABLE_NAME   = fk.TABLE_NAME AND
+		c.COLUMN_NAME  = fk.COLUMN_NAME
+	
+	INNER JOIN INFORMATION_SCHEMA.TABLES t ON
+		c.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = t.TABLE_SCHEMA COLLATE DATABASE_DEFAULT AND
+		c.TABLE_NAME   COLLATE DATABASE_DEFAULT = t.TABLE_NAME   COLLATE DATABASE_DEFAULT
+
+	LEFT OUTER JOIN
+	(
+		SELECT
+			st.object_id,
+			[st].[temporal_type] AS temporal_type
+		FROM
+			sys.tables AS st
+	) AS tt ON c.table_object_id = tt.object_id
+
+ORDER BY
+	c.TABLE_SCHEMA,
+	c.TABLE_NAME,
+	c.ORDINAL_POSITION;
+";
 
         private const string SynonymTableSQLSetup = @"
 SET NOCOUNT ON;
@@ -1802,143 +1870,163 @@ SELECT TOP (0)
         c.is_nullable AS IsNullable,
         ISNULL(TYPE_NAME(c.system_type_id), t.name) AS TypeName,
         ISNULL(COLUMNPROPERTY(c.object_id, c.name, 'charmaxlen'), 0) AS MaxLength,
-        CAST(ISNULL(CONVERT(TINYINT, CASE WHEN c.system_type_id IN (48, 52, 56, 59, 60, 62, 106, 108, 122, 127) THEN c.precision
-                                     END), 0) AS INT) AS Precision,
+	CAST(ISNULL(CONVERT(TINYINT, CASE WHEN c.system_type_id IN (48, 52, 56, 59, 60, 62, 106, 108, 122, 127) THEN c.precision END), 0) AS INT) AS Precision,
         ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '') AS [Default],
-        CAST(ISNULL(CONVERT(SMALLINT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN ODBCSCALE(c.system_type_id, c.scale)
-                                      END), 0) AS INT) AS DateTimePrecision,
-        ISNULL(CONVERT(INT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN NULL
-                                 ELSE ODBCSCALE(c.system_type_id, c.scale)
-                            END), 0) AS Scale,
+	CAST(ISNULL(CONVERT(SMALLINT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN ODBCSCALE(c.system_type_id, c.scale) END), 0) AS INT) AS DateTimePrecision,
+	ISNULL(CONVERT(INT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN NULL ELSE ODBCSCALE(c.system_type_id, c.scale) END), 0) AS Scale,
         CAST(COLUMNPROPERTY(OBJECT_ID(sn.base_object_name), c.NAME, 'IsIdentity') AS BIT) AS IsIdentity,
-        CAST(CASE WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'IsIdentity') = 1 THEN 1
+	CAST(CASE
+		WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'IsIdentity') = 1 THEN 1
                   WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'IsComputed') = 1 THEN 1
                   WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'GeneratedAlwaysType') > 0 THEN 1
                   WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = 'TIMESTAMP' THEN 1
-                  WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = 'UNIQUEIDENTIFIER'
-                       AND LOWER(ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '')) LIKE '%newsequentialid%' THEN 1
+		WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = 'UNIQUEIDENTIFIER' AND LOWER(ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '')) LIKE '%newsequentialid%' THEN 1
                   ELSE 0
              END AS BIT) AS IsStoreGenerated,
-        CAST(CASE WHEN pk.ORDINAL_POSITION IS NULL THEN 0
-                  ELSE 1
-             END AS BIT) AS PrimaryKey,
+	CAST(CASE WHEN pk.ORDINAL_POSITION IS NULL THEN 0 ELSE 1 END AS BIT) AS PrimaryKey,
         ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
-        CAST(CASE WHEN fk.COLUMN_NAME IS NULL THEN 0
-                  ELSE 1
-             END AS BIT) AS IsForeignKey
-INTO    #SynonymDetails
-FROM    sys.synonyms sn
-        INNER JOIN sys.COLUMNS c
-            ON c.[object_id] = OBJECT_ID(sn.base_object_name)
-        INNER JOIN sys.schemas sc
-            ON sc.[schema_id] = sn.[schema_id]
-        LEFT JOIN sys.types t
-            ON c.user_type_id = t.user_type_id
-        INNER JOIN sys.objects o
-            ON c.[object_id] = o.[object_id]
-        LEFT OUTER JOIN (SELECT u.TABLE_SCHEMA,
+	CAST(CASE WHEN fk.COLUMN_NAME IS NULL THEN 0 ELSE 1 END AS BIT) AS IsForeignKey
+INTO
+	#SynonymDetails
+FROM
+	sys.synonyms sn
+	INNER JOIN sys.COLUMNS c ON c.[object_id] = OBJECT_ID(sn.base_object_name)
+	INNER JOIN sys.schemas sc ON sc.[schema_id] = sn.[schema_id]
+	LEFT JOIN sys.types t ON c.user_type_id = t.user_type_id
+	INNER JOIN sys.objects o ON c.[object_id] = o.[object_id]
+	LEFT OUTER JOIN
+	(
+		SELECT
+			u.TABLE_SCHEMA,
                                 u.TABLE_NAME,
                                 u.COLUMN_NAME,
                                 u.ORDINAL_POSITION
-                         FROM   INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
-                                INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-                                    ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA
-                                       AND u.TABLE_NAME = tc.TABLE_NAME
-                                       AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
-                         WHERE  CONSTRAINT_TYPE = 'PRIMARY KEY') pk
-            ON sc.NAME = pk.TABLE_SCHEMA
-               AND sn.name = pk.TABLE_NAME
-               AND c.name = pk.COLUMN_NAME
-        LEFT OUTER JOIN (SELECT DISTINCT
+        FROM 
+			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+            INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND u.TABLE_NAME = tc.TABLE_NAME AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+        WHERE
+			CONSTRAINT_TYPE = 'PRIMARY KEY'
+	) pk
+        ON sc.NAME = pk.TABLE_SCHEMA AND sn.name = pk.TABLE_NAME AND c.name = pk.COLUMN_NAME
+    
+	LEFT OUTER JOIN
+	(
+		SELECT DISTINCT
                                 u.TABLE_SCHEMA,
                                 u.TABLE_NAME,
                                 u.COLUMN_NAME
-                         FROM   INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
-                                INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-                                    ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA
-                                       AND u.TABLE_NAME = tc.TABLE_NAME
-                                       AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
-                         WHERE  CONSTRAINT_TYPE = 'FOREIGN KEY') fk
-            ON sc.NAME = fk.TABLE_SCHEMA
-               AND sn.name = fk.TABLE_NAME
-               AND c.name = fk.COLUMN_NAME;
+        FROM
+			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+            INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND u.TABLE_NAME = tc.TABLE_NAME AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+        WHERE
+			CONSTRAINT_TYPE = 'FOREIGN KEY'
+	) fk
+        ON sc.NAME = fk.TABLE_SCHEMA AND sn.name = fk.TABLE_NAME AND c.name = fk.COLUMN_NAME;
 
 DECLARE @synonymDetailsQueryTemplate nvarchar(max) = 'USE [@synonmymDatabaseName];
-INSERT INTO #SynonymDetails (SchemaName, TableName, TableType, Ordinal, ColumnName, IsNullable, TypeName, [MaxLength], [Precision],
-                            [Default], DateTimePrecision, Scale, IsIdentity, IsStoreGenerated, PrimaryKey, PrimaryKeyOrdinal, IsForeignKey)
-SELECT st.SynonymSchemaName AS SchemaName,
+INSERT INTO #SynonymDetails (
+	SchemaName, TableName, TableType, TableTemporalType, Ordinal, ColumnName, IsNullable, TypeName, [MaxLength], [Precision], [Default], DateTimePrecision, Scale,
+	IsIdentity, IsRowGuid, IsComputed, GeneratedAlwaysType, IsStoreGenerated, PrimaryKey, PrimaryKeyOrdinal, IsForeignKey
+)
+SELECT
+	st.SynonymSchemaName AS SchemaName,
     st.SynonymName AS TableName,
     ''SN'' AS TableType,
+	CONVERT( tinyint, ISNULL( tt.temporal_type, 0 ) ) AS TableTemporalType,
+
     COLUMNPROPERTY(c.object_id, c.name, ''ordinal'') AS Ordinal,
     c.name AS ColumnName,
     c.is_nullable AS IsNullable,
     ISNULL(TYPE_NAME(c.system_type_id), t.name) AS TypeName,
     ISNULL(COLUMNPROPERTY(c.object_id, c.name, ''charmaxlen''), 0) AS [MaxLength],
-    CAST(ISNULL(CONVERT(TINYINT, CASE WHEN c.system_type_id IN (48, 52, 56, 59, 60, 62, 106, 108, 122, 127) THEN c.precision
-                                    END), 0) AS INT) AS [Precision],
+    CAST(ISNULL(CONVERT(TINYINT, CASE WHEN c.system_type_id IN (48, 52, 56, 59, 60, 62, 106, 108, 122, 127) THEN c.precision END), 0) AS INT) AS [Precision],
     ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '''') AS [Default],
-    CAST(ISNULL(CONVERT(SMALLINT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN ODBCSCALE(c.system_type_id, c.scale)
-                                    END), 0) AS INT) AS DateTimePrecision,
-    ISNULL(CONVERT(INT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN NULL
-                                ELSE ODBCSCALE(c.system_type_id, c.scale)
-                        END), 0) AS Scale,
-    CAST(COLUMNPROPERTY(st.base_object_id, c.name, ''IsIdentity'') AS BIT) AS IsIdentity,
-    CAST(CASE WHEN COLUMNPROPERTY(st.base_object_id, c.NAME, ''IsIdentity'') = 1 THEN 1
-                WHEN COLUMNPROPERTY(st.base_object_id, c.NAME, ''IsComputed'') = 1 THEN 1
-                WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = ''TIMESTAMP'' THEN 1
-                WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = ''UNIQUEIDENTIFIER''
-                    AND LOWER(ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '''')) LIKE ''%newsequentialid%'' THEN 1
+    CAST(ISNULL(CONVERT(SMALLINT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN ODBCSCALE(c.system_type_id, c.scale) END), 0) AS INT) AS DateTimePrecision,
+    ISNULL(CONVERT(INT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN NULL ELSE ODBCSCALE(c.system_type_id, c.scale) END), 0) AS Scale,
+
+	c.is_identity AS IsIdentity,
+	c.is_rowguidcol AS IsRowGuid,
+	c.is_computed AS IsComputed,
+	CONVERT( tinyint, [c].[generated_always_type] ) AS GeneratedAlwaysType,
+
+	CONVERT( bit, 
+		CASE
+			WHEN
+				c.is_identity = 1 OR
+				c.is_rowguidcol = 1 OR
+				c.is_computed = 1 OR
+				[c].[generated_always_type] <> 0 OR
+				c.DATA_TYPE IN ( 'rowversion', 'timestamp' ) OR
+				( c.DATA_TYPE = 'uniqueidentifier' AND c.COLUMN_DEFAULT LIKE '%newsequentialid%' )
+				THEN 1
                 ELSE 0
-            END AS BIT) AS IsStoreGenerated,
-    CAST(CASE WHEN pk.ORDINAL_POSITION IS NULL THEN 0
-                ELSE 1
-            END AS BIT) AS PrimaryKey,
+		END
+	) AS IsStoreGenerated,
+
+    CAST(CASE WHEN pk.ORDINAL_POSITION IS NULL THEN 0  ELSE 1 END AS BIT) AS PrimaryKey,
     ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
-    CAST(CASE WHEN fk.COLUMN_NAME IS NULL THEN 0
-                ELSE 1
-            END AS BIT) AS IsForeignKey
-FROM    #SynonymTargets st
-    INNER JOIN sys.columns c
-        ON c.[object_id] = st.base_object_id
-    LEFT JOIN sys.types t
-        ON c.user_type_id = t.user_type_id
-    INNER JOIN sys.objects o
-        ON c.[object_id] = o.[object_id]
-    LEFT OUTER JOIN (
-                        SELECT u.TABLE_SCHEMA,
+    CAST(CASE WHEN fk.COLUMN_NAME IS NULL THEN 0 ELSE 1 END AS BIT) AS IsForeignKey
+FROM
+	#SynonymTargets st
+    
+	INNER JOIN sys.columns c ON c.[object_id] = st.base_object_id
+    
+	LEFT JOIN sys.types t ON c.user_type_id = t.user_type_id
+    
+	INNER JOIN sys.objects o ON c.[object_id] = o.[object_id]
+    
+	LEFT OUTER JOIN
+	(
+		SELECT
+			u.TABLE_SCHEMA,
                             u.TABLE_NAME,
                             u.COLUMN_NAME,
                             u.ORDINAL_POSITION
-                        FROM   INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
-                            INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-                                ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA
-                                    AND u.TABLE_NAME = tc.TABLE_NAME
-                                    AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
-                        WHERE  CONSTRAINT_TYPE = ''PRIMARY KEY''
-                    ) pk
-        ON st.SchemaName = pk.TABLE_SCHEMA
-            AND st.ObjectName = pk.TABLE_NAME
-            AND c.name = pk.COLUMN_NAME
-    LEFT OUTER JOIN (
+		FROM
+			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+			INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND u.TABLE_NAME = tc.TABLE_NAME AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+		WHERE
+			CONSTRAINT_TYPE = ''PRIMARY KEY''
+    ) AS pk ON
+		st.SchemaName = pk.TABLE_SCHEMA AND
+		st.ObjectName = pk.TABLE_NAME AND
+		c.name        = pk.COLUMN_NAME
+    
+	LEFT OUTER JOIN
+	(
                         SELECT DISTINCT
                             u.TABLE_SCHEMA,
                             u.TABLE_NAME,
                             u.COLUMN_NAME
-                        FROM   INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
-                            INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-                                ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA
-                                    AND u.TABLE_NAME = tc.TABLE_NAME
-                                    AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
-                        WHERE  CONSTRAINT_TYPE = ''FOREIGN KEY''
-                    ) fk
-        ON st.SchemaName = fk.TABLE_SCHEMA
-            AND st.ObjectName = fk.TABLE_NAME
-            AND c.name = fk.COLUMN_NAME
-WHERE st.DatabaseName = @synonmymDatabaseName;
+        FROM
+			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+            INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON
+				u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND
+				u.TABLE_NAME = tc.TABLE_NAME AND
+				u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+        WHERE
+			CONSTRAINT_TYPE = ''FOREIGN KEY''
+    ) AS fk ON
+		st.SchemaName = fk.TABLE_SCHEMA AND
+		st.ObjectName = fk.TABLE_NAME AND
+		c.name = fk.COLUMN_NAME
+
+	LEFT OUTER JOIN
+	(
+		SELECT
+			st.object_id,
+			[st].[temporal_type] AS temporal_type
+		FROM
+			sys.tables AS st
+	) AS tt ON c.object_id = tt.object_id
+
+WHERE
+	st.DatabaseName = @synonmymDatabaseName;
 '
 
 -- Pull details about the synonym target from each database being referenced
-SELECT  sc.name AS SynonymSchemaName,
+SELECT
+	sc.name AS SynonymSchemaName,
         sn.name AS SynonymName,
         sn.object_id,
         sn.base_object_name,
@@ -1947,11 +2035,13 @@ SELECT  sc.name AS SynonymSchemaName,
         ISNULL(PARSENAME(sn.base_object_name, 2), sc.name) AS SchemaName,
         ISNULL(PARSENAME(sn.base_object_name, 3), DB_NAME()) AS DatabaseName,
         PARSENAME(sn.base_object_name, 4) AS ServerName
-INTO    #SynonymTargets
-FROM    sys.synonyms sn
-        INNER JOIN sys.schemas sc
-            ON sc.schema_id = sn.schema_id
-WHERE   ISNULL(PARSENAME(sn.base_object_name, 4), @@SERVERNAME) = @@SERVERNAME; -- Only populate info from current server
+INTO
+	#SynonymTargets
+FROM
+	sys.synonyms sn
+    INNER JOIN sys.schemas sc ON sc.schema_id = sn.schema_id
+WHERE
+	ISNULL(PARSENAME(sn.base_object_name, 4), @@SERVERNAME) = @@SERVERNAME; -- Only populate info from current server
 
 -- Loop through synonyms and populate #SynonymDetails
 DECLARE @synonmymDatabaseName sysname = (SELECT TOP (1) DatabaseName FROM #SynonymTargets)
@@ -1970,8 +2060,33 @@ SET NOCOUNT OFF;
         private const string SynonymTableSQL = @"
 UNION
 -- Synonyms
-SELECT SchemaName, TableName, TableType, Ordinal, ColumnName, IsNullable, TypeName, [MaxLength], [Precision],
-    [Default], DateTimePrecision, Scale, IsIdentity, IsStoreGenerated, PrimaryKey, PrimaryKeyOrdinal, IsForeignKey FROM #SynonymDetails";
+SELECT
+	SchemaName,
+	TableName,
+	TableType,
+	CONVERT( tinyint, 0 ) AS TableTemporalType,
+
+	Ordinal,
+	ColumnName,
+	IsNullable,
+	TypeName,
+	[MaxLength],
+	[Precision],
+    [Default],
+	DateTimePrecision,
+	Scale,
+
+	IsIdentity,
+	IsRowGuid,
+	IsComputed,
+	GeneratedAlwaysType,
+
+	IsStoreGenerated,
+	PrimaryKey,
+	PrimaryKeyOrdinal,
+	IsForeignKey
+FROM
+	#SynonymDetails";
 
             private const string ForeignKeySQL = @"
 SELECT  fkData.FK_Table,
@@ -2148,51 +2263,38 @@ FROM    [__ExtendedProperties]";
 SELECT  '' AS SchemaName,
     c.TABLE_NAME AS TableName,
     'BASE TABLE' AS TableType,
+	CONVERT( tinyint, 0 ) AS TableTemporalType,
     c.ORDINAL_POSITION AS Ordinal,
     c.COLUMN_NAME AS ColumnName,
-    CAST(CASE WHEN c.IS_NULLABLE = N'YES' THEN 1
-                ELSE 0
-            END AS BIT) AS IsNullable,
-    CASE WHEN c.DATA_TYPE = N'rowversion' THEN 'timestamp'
-            ELSE c.DATA_TYPE
-    END AS TypeName,
-    CASE WHEN c.CHARACTER_MAXIMUM_LENGTH IS NOT NULL THEN c.CHARACTER_MAXIMUM_LENGTH
-            ELSE 0
-    END AS MaxLength,
-    CASE WHEN c.NUMERIC_PRECISION IS NOT NULL THEN c.NUMERIC_PRECISION
-            ELSE 0
-    END AS Precision,
+    CAST(CASE WHEN c.IS_NULLABLE = N'YES' THEN 1 ELSE 0 END AS BIT) AS IsNullable,
+    CASE WHEN c.DATA_TYPE = N'rowversion' THEN 'timestamp' ELSE c.DATA_TYPE END AS TypeName,
+    CASE WHEN c.CHARACTER_MAXIMUM_LENGTH IS NOT NULL THEN c.CHARACTER_MAXIMUM_LENGTH ELSE 0 END AS MaxLength,
+    CASE WHEN c.NUMERIC_PRECISION IS NOT NULL THEN c.NUMERIC_PRECISION ELSE 0 END AS Precision,
     c.COLUMN_DEFAULT AS [Default],
-    CASE WHEN c.DATA_TYPE = N'datetime' THEN 0
-            ELSE 0
-    END AS DateTimePrecision,
-    CASE WHEN c.DATA_TYPE = N'datetime' THEN 0
-            WHEN c.NUMERIC_SCALE IS NOT NULL THEN c.NUMERIC_SCALE
-            ELSE 0
-    END AS Scale,
-    CAST(CASE WHEN c.AUTOINC_INCREMENT > 0 THEN 1
-                ELSE 0
-            END AS BIT) AS IsIdentity,
-    CAST(CASE WHEN c.DATA_TYPE = N'rowversion' THEN 1
-                ELSE 0
-            END AS BIT) AS IsStoreGenerated,
-    CAST(CASE WHEN u.TABLE_NAME IS NULL THEN 0
-                ELSE 1
-            END AS BIT) AS PrimaryKey,
+    CASE WHEN c.DATA_TYPE = N'datetime' THEN 0 ELSE 0 END AS DateTimePrecision,
+    CASE WHEN c.DATA_TYPE = N'datetime' THEN 0 WHEN c.NUMERIC_SCALE IS NOT NULL THEN c.NUMERIC_SCALE ELSE 0 END AS Scale,
+
+    CAST(CASE WHEN c.AUTOINC_INCREMENT > 0 THEN 1 ELSE 0 END AS BIT) AS IsIdentity,
+	0 AS IsRowGuid,
+	0 AS IsComputed,
+	CONVERT( tinyint, 0 ) AS GeneratedAlwaysType,
+    CAST(CASE WHEN c.DATA_TYPE = N'rowversion' THEN 1 ELSE 0 END AS BIT) AS IsStoreGenerated,
+    CAST(CASE WHEN u.TABLE_NAME IS NULL THEN 0 ELSE 1 END AS BIT) AS PrimaryKey,
     0 AS PrimaryKeyOrdinal,
-    0 as IsForeignKey
-FROM    INFORMATION_SCHEMA.COLUMNS c
-    INNER JOIN INFORMATION_SCHEMA.TABLES t
-        ON c.TABLE_NAME = t.TABLE_NAME
-    LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS cons
-        ON cons.TABLE_NAME = c.TABLE_NAME
-    LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS u
-        ON cons.CONSTRAINT_NAME = u.CONSTRAINT_NAME
-            AND u.TABLE_NAME = c.TABLE_NAME
-            AND u.COLUMN_NAME = c.COLUMN_NAME
-WHERE   t.TABLE_TYPE <> N'SYSTEM TABLE'
-    AND cons.CONSTRAINT_TYPE = 'PRIMARY KEY'
-ORDER BY c.TABLE_NAME,
+    CONVERT( bit, 0 ) as IsForeignKey
+FROM
+	INFORMATION_SCHEMA.COLUMNS c
+    INNER JOIN INFORMATION_SCHEMA.TABLES t ON c.TABLE_NAME = t.TABLE_NAME
+    LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS cons ON cons.TABLE_NAME = c.TABLE_NAME
+    LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS u ON
+		cons.CONSTRAINT_NAME = u.CONSTRAINT_NAME AND
+        u.TABLE_NAME = c.TABLE_NAME AND
+        u.COLUMN_NAME = c.COLUMN_NAME
+WHERE
+	t.TABLE_TYPE <> N'SYSTEM TABLE' AND
+	cons.CONSTRAINT_TYPE = 'PRIMARY KEY'
+ORDER BY
+	c.TABLE_NAME,
     c.COLUMN_NAME,
     c.ORDINAL_POSITION";
 

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -1069,8 +1069,9 @@
                 : "System.ComponentModel.DataAnnotations.Schema.";
 
             bool isNewSequentialId = !string.IsNullOrEmpty(Default)  && Default.ToLower().Contains("newsequentialid");
+            bool isTemporalColumn = this.GeneratedAlwaysType != ColumnGeneratedAlwaysType.NotApplicable; 
 
-            if (IsIdentity || isNewSequentialId)
+            if (IsIdentity || isNewSequentialId || isTemporalColumn) // Identity, instead of Computed, seems the best for Temporal `GENERATED ALWAYS` columns: https://stackoverflow.com/questions/40742142/entity-framework-not-working-with-temporal-table
             {
                 if(Settings.UseDataAnnotations || isNewSequentialId)
                     DataAnnotations.Add("DatabaseGenerated(DatabaseGeneratedOption.Identity)");

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -105,6 +105,7 @@
         public static bool UseMappingTables;
         public static bool UsePropertyInitializers;
         public static bool IsSqlCe;
+		public static bool TemporalTableSupport;
         public static string FileExtension = ".cs";
         public static bool UsePascalCase;
         public static bool UsePrivateSetterForComputedColumns;
@@ -752,7 +753,7 @@
         catch(Exception x)
         {
 			PrintError( "Failed to read database schema in LoadTables().", x );
-            return new Tables();
+			return new Tables();
         }
     }
 
@@ -973,6 +974,9 @@
         public bool AllowEmptyStrings = true;
 
         public bool IsIdentity;
+		public bool IsRowGuid;
+		public bool IsComputed;
+		public ColumnGeneratedAlwaysType GeneratedAlwaysType;
         public bool IsNullable;
         public bool IsPrimaryKey;
         public bool IsUniqueConstraint;
@@ -1043,7 +1047,10 @@
                     inlineComments += ". " + ExtendedProperty;
             }
             var initialization = Settings.UsePropertyInitializers ? (Default == string.Empty ? "" : string.Format(" = {0};", Default)) : "";
-            Entity = string.Format("public {0}{1} {2} {{ get; {3}set; }}{4}{5}", (OverrideModifier ? "override " : ""), WrapIfNullable(PropertyType, this), NameHumanCase, Settings.UsePrivateSetterForComputedColumns && IsComputed() ? "private " : string.Empty, initialization, inlineComments);
+            Entity = string.Format(
+				"public {0}{1} {2} {{ get; {3}set; }}{4}{5}",
+				(OverrideModifier ? "override " : ""), WrapIfNullable(PropertyType, this), NameHumanCase, Settings.UsePrivateSetterForComputedColumns && IsComputed ? "private " : string.Empty, initialization, inlineComments
+			);
         }
 
         private string WrapIfNullable(string propType, Column col)
@@ -1051,11 +1058,6 @@
             if(!IsNullable(col))
                 return propType;
             return string.Format(Settings.NullableShortHand ? "{0}?" : "System.Nullable<{0}>",propType);
-        }
-
-        private bool IsComputed()
-        {
-            return IsStoreGenerated && !IsIdentity;
         }
 
         private void SetupConfig()
@@ -1075,7 +1077,7 @@
                 else
                     databaseGeneratedOption = string.Format(".HasDatabaseGeneratedOption({0}DatabaseGeneratedOption.Identity)", schemaReference);
             }
-            else if(IsComputed())
+            else if(IsComputed)
             {
                 if(Settings.UseDataAnnotations)
                     DataAnnotations.Add("DatabaseGenerated(DatabaseGeneratedOption.Computed)");
@@ -1115,7 +1117,7 @@
             }
             else
             {
-                if (!IsComputed() && (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent))
+                if (!IsComputed && (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent))
                 {
                     if (PropertyType.Equals("string", StringComparison.InvariantCultureIgnoreCase) && this.AllowEmptyStrings)
                     {
@@ -1735,7 +1737,7 @@ WHERE
 
 
 CREATE NONCLUSTERED INDEX IX_EfPoco_Columns
-ON dbo.#Columns (TABLE_NAME)
+	ON dbo.#Columns (TABLE_NAME)
 	INCLUDE (
 		TABLE_SCHEMA,COLUMN_NAME,ORDINAL_POSITION,COLUMN_DEFAULT,IS_NULLABLE,DATA_TYPE,CHARACTER_MAXIMUM_LENGTH,NUMERIC_PRECISION,NUMERIC_SCALE,DATETIME_PRECISION,
 		schema_id, table_object_id, view_object_id,
@@ -1747,9 +1749,9 @@ ON dbo.#Columns (TABLE_NAME)
 -----------
 SELECT
 	u.TABLE_SCHEMA,
-        u.TABLE_NAME,
-        u.COLUMN_NAME,
-        u.ORDINAL_POSITION
+	u.TABLE_NAME,
+	u.COLUMN_NAME,
+	u.ORDINAL_POSITION
 INTO
 	#PrimaryKeys
 FROM
@@ -1764,9 +1766,9 @@ WHERE
 	CONSTRAINT_TYPE = 'PRIMARY KEY';
 
 SELECT DISTINCT
-        u.TABLE_SCHEMA,
-        u.TABLE_NAME,
-        u.COLUMN_NAME
+	u.TABLE_SCHEMA,
+	u.TABLE_NAME,
+	u.COLUMN_NAME
 INTO
 	#ForeignKeys
 FROM
@@ -1784,19 +1786,19 @@ WHERE
 
 SELECT
 	c.TABLE_SCHEMA AS SchemaName,
-        c.TABLE_NAME AS TableName,
-        t.TABLE_TYPE AS TableType,
+	c.TABLE_NAME AS TableName,
+	t.TABLE_TYPE AS TableType,
 	CONVERT( tinyint, ISNULL( tt.temporal_type, 0 ) ) AS TableTemporalType,
 
-        c.ORDINAL_POSITION AS Ordinal,
-        c.COLUMN_NAME AS ColumnName,
+	c.ORDINAL_POSITION AS Ordinal,
+	c.COLUMN_NAME AS ColumnName,
 	c.is_nullable AS IsNullable,
-        DATA_TYPE AS TypeName,
+	DATA_TYPE AS TypeName,
 	ISNULL(CHARACTER_MAXIMUM_LENGTH, 0) AS [MaxLength],
 	CAST(ISNULL(NUMERIC_PRECISION, 0) AS INT) AS [Precision],
-        ISNULL(COLUMN_DEFAULT, '') AS [Default],
-        CAST(ISNULL(DATETIME_PRECISION, 0) AS INT) AS DateTimePrecision,
-        ISNULL(NUMERIC_SCALE, 0) AS Scale,
+	ISNULL(COLUMN_DEFAULT, '') AS [Default],
+	CAST(ISNULL(DATETIME_PRECISION, 0) AS INT) AS DateTimePrecision,
+	ISNULL(NUMERIC_SCALE, 0) AS Scale,
 
 	c.is_identity AS IsIdentity,
 	c.is_rowguidcol AS IsRowGuid,
@@ -1818,7 +1820,7 @@ SELECT
 	) AS IsStoreGenerated,
 	
 	CONVERT( bit, ISNULL( pk.ORDINAL_POSITION, 0 ) ) AS PrimaryKey,
-        ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
+	ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
 	CONVERT( bit, CASE WHEN fk.COLUMN_NAME IS NOT NULL THEN 1 ELSE 0 END ) AS IsForeignKey
 
 FROM
@@ -1862,29 +1864,29 @@ IF OBJECT_ID('tempdb..#SynonymTargets') IS NOT NULL DROP TABLE #SynonymTargets;
 -- Synonyms
 -- Create the #SynonymDetails temp table structure for later use
 SELECT TOP (0)
-        sc.name AS SchemaName,
-        sn.name AS TableName,
-        'SN' AS TableType,
-        COLUMNPROPERTY(c.object_id, c.name, 'ordinal') AS Ordinal,
-        c.name AS ColumnName,
-        c.is_nullable AS IsNullable,
-        ISNULL(TYPE_NAME(c.system_type_id), t.name) AS TypeName,
-        ISNULL(COLUMNPROPERTY(c.object_id, c.name, 'charmaxlen'), 0) AS MaxLength,
+	sc.name AS SchemaName,
+	sn.name AS TableName,
+	'SN' AS TableType,
+	COLUMNPROPERTY(c.object_id, c.name, 'ordinal') AS Ordinal,
+	c.name AS ColumnName,
+	c.is_nullable AS IsNullable,
+	ISNULL(TYPE_NAME(c.system_type_id), t.name) AS TypeName,
+	ISNULL(COLUMNPROPERTY(c.object_id, c.name, 'charmaxlen'), 0) AS MaxLength,
 	CAST(ISNULL(CONVERT(TINYINT, CASE WHEN c.system_type_id IN (48, 52, 56, 59, 60, 62, 106, 108, 122, 127) THEN c.precision END), 0) AS INT) AS Precision,
-        ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '') AS [Default],
+	ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '') AS [Default],
 	CAST(ISNULL(CONVERT(SMALLINT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN ODBCSCALE(c.system_type_id, c.scale) END), 0) AS INT) AS DateTimePrecision,
 	ISNULL(CONVERT(INT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN NULL ELSE ODBCSCALE(c.system_type_id, c.scale) END), 0) AS Scale,
-        CAST(COLUMNPROPERTY(OBJECT_ID(sn.base_object_name), c.NAME, 'IsIdentity') AS BIT) AS IsIdentity,
+	CAST(COLUMNPROPERTY(OBJECT_ID(sn.base_object_name), c.NAME, 'IsIdentity') AS BIT) AS IsIdentity,
 	CAST(CASE
 		WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'IsIdentity') = 1 THEN 1
-                  WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'IsComputed') = 1 THEN 1
-                  WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'GeneratedAlwaysType') > 0 THEN 1
-                  WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = 'TIMESTAMP' THEN 1
+		WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'IsComputed') = 1 THEN 1
+		WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'GeneratedAlwaysType') > 0 THEN 1
+		WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = 'TIMESTAMP' THEN 1
 		WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = 'UNIQUEIDENTIFIER' AND LOWER(ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '')) LIKE '%newsequentialid%' THEN 1
-                  ELSE 0
-             END AS BIT) AS IsStoreGenerated,
+		ELSE 0
+	END AS BIT) AS IsStoreGenerated,
 	CAST(CASE WHEN pk.ORDINAL_POSITION IS NULL THEN 0 ELSE 1 END AS BIT) AS PrimaryKey,
-        ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
+	ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
 	CAST(CASE WHEN fk.COLUMN_NAME IS NULL THEN 0 ELSE 1 END AS BIT) AS IsForeignKey
 INTO
 	#SynonymDetails
@@ -1898,9 +1900,9 @@ FROM
 	(
 		SELECT
 			u.TABLE_SCHEMA,
-                                u.TABLE_NAME,
-                                u.COLUMN_NAME,
-                                u.ORDINAL_POSITION
+            u.TABLE_NAME,
+            u.COLUMN_NAME,
+            u.ORDINAL_POSITION
         FROM 
 			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
             INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND u.TABLE_NAME = tc.TABLE_NAME AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
@@ -1912,9 +1914,9 @@ FROM
 	LEFT OUTER JOIN
 	(
 		SELECT DISTINCT
-                                u.TABLE_SCHEMA,
-                                u.TABLE_NAME,
-                                u.COLUMN_NAME
+			u.TABLE_SCHEMA,
+			u.TABLE_NAME,
+			u.COLUMN_NAME
         FROM
 			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
             INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND u.TABLE_NAME = tc.TABLE_NAME AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
@@ -1959,7 +1961,7 @@ SELECT
 				c.DATA_TYPE IN ( 'rowversion', 'timestamp' ) OR
 				( c.DATA_TYPE = 'uniqueidentifier' AND c.COLUMN_DEFAULT LIKE '%newsequentialid%' )
 				THEN 1
-                ELSE 0
+			ELSE 0
 		END
 	) AS IsStoreGenerated,
 
@@ -1979,9 +1981,9 @@ FROM
 	(
 		SELECT
 			u.TABLE_SCHEMA,
-                            u.TABLE_NAME,
-                            u.COLUMN_NAME,
-                            u.ORDINAL_POSITION
+			u.TABLE_NAME,
+			u.COLUMN_NAME,
+			u.ORDINAL_POSITION
 		FROM
 			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
 			INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND u.TABLE_NAME = tc.TABLE_NAME AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
@@ -1994,10 +1996,10 @@ FROM
     
 	LEFT OUTER JOIN
 	(
-                        SELECT DISTINCT
-                            u.TABLE_SCHEMA,
-                            u.TABLE_NAME,
-                            u.COLUMN_NAME
+        SELECT DISTINCT
+            u.TABLE_SCHEMA,
+            u.TABLE_NAME,
+            u.COLUMN_NAME
         FROM
 			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
             INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON
@@ -2027,14 +2029,14 @@ WHERE
 -- Pull details about the synonym target from each database being referenced
 SELECT
 	sc.name AS SynonymSchemaName,
-        sn.name AS SynonymName,
-        sn.object_id,
-        sn.base_object_name,
-        OBJECT_ID(sn.base_object_name) AS base_object_id,
-        PARSENAME(sn.base_object_name, 1) AS ObjectName,
-        ISNULL(PARSENAME(sn.base_object_name, 2), sc.name) AS SchemaName,
-        ISNULL(PARSENAME(sn.base_object_name, 3), DB_NAME()) AS DatabaseName,
-        PARSENAME(sn.base_object_name, 4) AS ServerName
+	sn.name AS SynonymName,
+	sn.object_id,
+	sn.base_object_name,
+	OBJECT_ID(sn.base_object_name) AS base_object_id,
+	PARSENAME(sn.base_object_name, 1) AS ObjectName,
+	ISNULL(PARSENAME(sn.base_object_name, 2), sc.name) AS SchemaName,
+	ISNULL(PARSENAME(sn.base_object_name, 3), DB_NAME()) AS DatabaseName,
+	PARSENAME(sn.base_object_name, 4) AS ServerName
 INTO
 	#SynonymTargets
 FROM
@@ -2681,6 +2683,14 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             else
                 Cmd.CommandTimeout = Settings.CommandTimeout;
 
+			if (!Settings.TemporalTableSupport)
+			{
+				Cmd.CommandText = Cmd.CommandText
+					.Replace("[sc].[generated_always_type]", "0" )
+					.Replace("[c].[generated_always_type]", "0" )
+					.Replace("[st].[temporal_type]", "0" );
+			}
+
             using(var rdr = Cmd.ExecuteReader())
             {
                 var rxClean = new Regex("^(event|Equals|GetHashCode|GetType|ToString|repo|Save|IsNew|Insert|Update|Delete|Exists|SingleOrDefault|Single|First|FirstOrDefault|Fetch|Page|Query)$");
@@ -2702,11 +2712,12 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         table = result.Find(x => x.Name == tableName && x.Schema == schema);
                         if(table == null)
                         {
-                            table = new Table
+							table = new Table
                             {
                                 Name = tableName,
                                 Schema = schema,
                                 IsView = string.Compare(rdr["TableType"].ToString().Trim(), "View", StringComparison.OrdinalIgnoreCase) == 0,
+								TemporalType = (TableTemporalType)(Byte)rdr["TableTemporalType"],
 
                                 // Will be set later
                                 HasForeignKey = false,
@@ -3367,28 +3378,45 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             if(rdr == null)
                 throw new ArgumentNullException("rdr");
 
-            string typename = rdr["TypeName"].ToString().Trim().ToLower();
-            var scale = (int) rdr["Scale"];
-            var precision = (int) rdr["Precision"];
+            string  typename      = rdr["TypeName"].ToString().Trim().ToLower();
+            Int32   rdrScale      = (int)rdr["Scale"];
+
+			Boolean rdrIsNullable = (Boolean)rdr["IsNullable"];
+			Int32   rdrMaxLength  = (int)rdr["MaxLength"];
+			Int32   rdrDtp        = (int)rdr["DateTimePrecision"];
+			Int32   rdrPrecision  = (int)rdr["Precision"];
+			Boolean rdrIsIdentity = (Boolean)rdr["IsIdentity"];
+			Boolean rdrIsComputed = (Boolean)rdr["IsComputed"];
+			Boolean rdrIsRowGuid  = (Boolean)rdr["IsRowGuid"];
+			Byte    rdrGat        = (Byte)rdr["GeneratedAlwaysType"];
+			Boolean rdrIsg        = (Boolean)rdr["IsStoreGenerated"];
+			Int32   rdrPko        = (int)rdr["PrimaryKeyOrdinal"];
+			Boolean rdrIsPk       = (Boolean)rdr["PrimaryKey"];
+			Boolean rdrIsFk       = (Boolean)rdr["IsForeignKey"];
 
             var col = new Column
             {
-                Name = rdr["ColumnName"].ToString().Trim(),
-                SqlPropertyType = typename,
-                PropertyType = GetPropertyType(typename),
-                MaxLength = (int)rdr["MaxLength"],
-                Precision = precision,
-                Default = rdr["Default"].ToString().Trim(),
-                DateTimePrecision = (int)rdr["DateTimePrecision"],
-                Scale = scale,
-                Ordinal = (int)rdr["Ordinal"],
-                IsIdentity = rdr["IsIdentity"].ToString().Trim().ToLower() == "true",
-                IsNullable = rdr["IsNullable"].ToString().Trim().ToLower() == "true",
-                IsStoreGenerated = rdr["IsStoreGenerated"].ToString().Trim().ToLower() == "true",
-                IsPrimaryKey = rdr["PrimaryKey"].ToString().Trim().ToLower() == "true",
-                PrimaryKeyOrdinal = (int)rdr["PrimaryKeyOrdinal"],
-                IsForeignKey = rdr["IsForeignKey"].ToString().Trim().ToLower() == "true",
-                ParentTable = table
+				Ordinal             = (int)rdr["Ordinal"],
+				Name                = rdr["ColumnName"].ToString().Trim(),
+				IsNullable          = rdrIsNullable,
+				PropertyType        = GetPropertyType(typename),
+				SqlPropertyType     = typename,
+                MaxLength           = rdrMaxLength,
+				Precision           = rdrPrecision,
+				Default             = rdr["Default"].ToString().Trim(),
+				DateTimePrecision   = rdrDtp,
+                Scale               = rdrScale,
+
+                IsIdentity          = rdrIsIdentity,
+				IsRowGuid           = rdrIsRowGuid,
+				IsComputed          = rdrIsComputed,
+				GeneratedAlwaysType = (ColumnGeneratedAlwaysType)rdrGat,
+				IsStoreGenerated    = rdrIsg,
+
+                IsPrimaryKey        = rdrIsPk,
+                PrimaryKeyOrdinal   = rdrPko,
+                IsForeignKey        = rdrIsFk,
+                ParentTable         = table
             };
 
             if (col.MaxLength == -1 && (col.SqlPropertyType.EndsWith("varchar", StringComparison.InvariantCultureIgnoreCase) || col.SqlPropertyType.EndsWith("varbinary", StringComparison.InvariantCultureIgnoreCase)))
@@ -3714,6 +3742,20 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
         public bool IsClustered;
     }
 
+	public enum TableTemporalType
+	{
+		None,
+		Verioned,
+		History
+	}
+
+	public enum ColumnGeneratedAlwaysType
+	{
+		NotApplicable = 0,
+		AsRowStart = 1,
+		AsRowEnd = 2
+	}
+
     public class Table
     {
         public string Name;
@@ -3728,6 +3770,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
         public bool HasForeignKey;
         public bool HasNullableColumns;
         public bool HasPrimaryKey;
+		public TableTemporalType TemporalType;
 
         public List<Column> Columns;
         public List<PropertyAndComments> ReverseNavigationProperty;

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -1110,10 +1110,16 @@
             }
             else
             {
-                if (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent)
+                if (!IsComputed() && (Settings.UseDataAnnotations || Settings.UseDataAnnotationsWithFluent))
                 {
-                    if(!IsComputed())
+                    if (PropertyType.Equals("string", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        DataAnnotations.Add("Required(AllowEmptyStrings = true)");
+                    }
+                    else
+                    {
                         DataAnnotations.Add("Required");
+                    }
                 }
 
                 if (!Settings.UseDataAnnotations)

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -600,6 +600,28 @@
         return rx.Replace(Settings.ConnectionString, "password=**zapped**;");
     }
 
+	public void PrintError(String message, Exception ex)
+	{
+		StringBuilder sb = new StringBuilder();
+		while( ex != null )
+		{
+			sb.AppendLine( ex.Message );
+			sb.AppendLine( ex.GetType().FullName );
+			sb.AppendLine( ex.StackTrace );
+			sb.AppendLine();
+			ex = ex.InnerException;
+		}
+		String report = sb.ToString();
+
+        Warning( message + " " + report );
+        WriteLine("");
+        WriteLine("// -----------------------------------------------------------------------------------------");
+        WriteLine("// " + message );
+        WriteLine("// -----------------------------------------------------------------------------------------");
+		WriteLine( report );
+        WriteLine("");
+	}
+
     private DbProviderFactory GetDbProviderFactory()
     {
         if (Settings.TargetFrameworkVersion < 1.0f)
@@ -639,13 +661,7 @@
             }
             catch (Exception x)
             {
-                var error = x.Message.Replace("\r\n", "\n").Replace("\n", " ");
-                Warning(string.Format("Failed to load provider \"{0}\" - {1}", Settings.ProviderName, error));
-                WriteLine("");
-                WriteLine("// ------------------------------------------------------------------------------------------------");
-                WriteLine("// Failed to load provider \"{0}\" - {1}", Settings.ProviderName, error);
-                WriteLine("// ------------------------------------------------------------------------------------------------");
-                WriteLine("");
+				PrintError( "Failed to load provider \"" + Settings.ProviderName + "\".", x );
             }
         }
         else
@@ -735,13 +751,7 @@
         }
         catch(Exception x)
         {
-            string error = x.Message.Replace("\r\n", "\n").Replace("\n", " ");
-            Warning(string.Format("Failed to read database schema - {0}", error));
-            WriteLine("");
-            WriteLine("// -----------------------------------------------------------------------------------------");
-            WriteLine("// Failed to read database schema in LoadTables() - {0}", error);
-            WriteLine("// -----------------------------------------------------------------------------------------");
-            WriteLine("");
+			PrintError( "Failed to read database schema in LoadTables().", x );
             return new Tables();
         }
     }
@@ -869,15 +879,9 @@
                 return validStoredProcedures;
             }
         }
-        catch(Exception x)
+        catch(Exception ex)
         {
-            var error = x.Message.Replace("\r\n", "\n").Replace("\n", " ");
-            Warning(string.Format("Failed to read database schema for stored procedures - {0}", error));
-            WriteLine("");
-            WriteLine("// -----------------------------------------------------------------------------------------");
-            WriteLine("// Failed to read database schema for stored procedures - {0}", error);
-            WriteLine("// -----------------------------------------------------------------------------------------");
-            WriteLine("");
+			PrintError( "Failed to read database schema for stored procedures.", ex );
             return new List<StoredProcedure>();
         }
     }

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -105,7 +105,7 @@
         public static bool UseMappingTables;
         public static bool UsePropertyInitializers;
         public static bool IsSqlCe;
-		public static bool TemporalTableSupport;
+        public static bool TemporalTableSupport;
         public static string FileExtension = ".cs";
         public static bool UsePascalCase;
         public static bool UsePrivateSetterForComputedColumns;
@@ -601,27 +601,27 @@
         return rx.Replace(Settings.ConnectionString, "password=**zapped**;");
     }
 
-	public void PrintError(String message, Exception ex)
-	{
-		StringBuilder sb = new StringBuilder();
-		while( ex != null )
-		{
-			sb.AppendLine( ex.Message );
-			sb.AppendLine( ex.GetType().FullName );
-			sb.AppendLine( ex.StackTrace );
-			sb.AppendLine();
-			ex = ex.InnerException;
-		}
-		String report = sb.ToString();
+    public void PrintError(String message, Exception ex)
+    {
+        StringBuilder sb = new StringBuilder();
+        while( ex != null )
+        {
+            sb.AppendLine( ex.Message );
+            sb.AppendLine( ex.GetType().FullName );
+            sb.AppendLine( ex.StackTrace );
+            sb.AppendLine();
+            ex = ex.InnerException;
+        }
+        String report = sb.ToString();
 
         Warning( message + " " + report );
         WriteLine("");
         WriteLine("// -----------------------------------------------------------------------------------------");
         WriteLine("// " + message );
         WriteLine("// -----------------------------------------------------------------------------------------");
-		WriteLine( report );
+        WriteLine( report );
         WriteLine("");
-	}
+    }
 
     private DbProviderFactory GetDbProviderFactory()
     {
@@ -662,7 +662,7 @@
             }
             catch (Exception x)
             {
-				PrintError( "Failed to load provider \"" + Settings.ProviderName + "\".", x );
+                PrintError( "Failed to load provider \"" + Settings.ProviderName + "\".", x );
             }
         }
         else
@@ -752,8 +752,8 @@
         }
         catch(Exception x)
         {
-			PrintError( "Failed to read database schema in LoadTables().", x );
-			return new Tables();
+            PrintError( "Failed to read database schema in LoadTables().", x );
+            return new Tables();
         }
     }
 
@@ -882,7 +882,7 @@
         }
         catch(Exception ex)
         {
-			PrintError( "Failed to read database schema for stored procedures.", ex );
+            PrintError( "Failed to read database schema for stored procedures.", ex );
             return new List<StoredProcedure>();
         }
     }
@@ -974,9 +974,9 @@
         public bool AllowEmptyStrings = true;
 
         public bool IsIdentity;
-		public bool IsRowGuid;
-		public bool IsComputed;
-		public ColumnGeneratedAlwaysType GeneratedAlwaysType;
+        public bool IsRowGuid;
+        public bool IsComputed;
+        public ColumnGeneratedAlwaysType GeneratedAlwaysType;
         public bool IsNullable;
         public bool IsPrimaryKey;
         public bool IsUniqueConstraint;
@@ -1048,9 +1048,9 @@
             }
             var initialization = Settings.UsePropertyInitializers ? (Default == string.Empty ? "" : string.Format(" = {0};", Default)) : "";
             Entity = string.Format(
-				"public {0}{1} {2} {{ get; {3}set; }}{4}{5}",
-				(OverrideModifier ? "override " : ""), WrapIfNullable(PropertyType, this), NameHumanCase, Settings.UsePrivateSetterForComputedColumns && IsComputed ? "private " : string.Empty, initialization, inlineComments
-			);
+                "public {0}{1} {2} {{ get; {3}set; }}{4}{5}",
+                (OverrideModifier ? "override " : ""), WrapIfNullable(PropertyType, this), NameHumanCase, Settings.UsePrivateSetterForComputedColumns && IsComputed ? "private " : string.Empty, initialization, inlineComments
+            );
         }
 
         private string WrapIfNullable(string propType, Column col)
@@ -1701,159 +1701,159 @@ IF OBJECT_ID('tempdb..#PrimaryKeys') IS NOT NULL DROP TABLE #PrimaryKeys;
 IF OBJECT_ID('tempdb..#ForeignKeys') IS NOT NULL DROP TABLE #ForeignKeys;
 
 SELECT
-	c.TABLE_SCHEMA,
-	c.TABLE_NAME,
-	c.COLUMN_NAME,
-	c.ORDINAL_POSITION,
-	c.COLUMN_DEFAULT,
-	sc.is_nullable,
-	c.DATA_TYPE,
-	c.CHARACTER_MAXIMUM_LENGTH,
-	c.NUMERIC_PRECISION,
-	c.NUMERIC_SCALE,
-	c.DATETIME_PRECISION,
+    c.TABLE_SCHEMA,
+    c.TABLE_NAME,
+    c.COLUMN_NAME,
+    c.ORDINAL_POSITION,
+    c.COLUMN_DEFAULT,
+    sc.is_nullable,
+    c.DATA_TYPE,
+    c.CHARACTER_MAXIMUM_LENGTH,
+    c.NUMERIC_PRECISION,
+    c.NUMERIC_SCALE,
+    c.DATETIME_PRECISION,
 
-	ss.schema_id,
-	st.object_id AS table_object_id,
-	sv.object_id AS view_object_id,
-	
-	sc.is_identity,
-	sc.is_rowguidcol,
-	sc.is_computed, -- Computed columns are read-only, do not confuse it with a column with a DEFAULT expression (which can be re-assigned). See the IsStoreGenerated attribute.
-	CONVERT( tinyint, [sc].[generated_always_type] ) AS generated_always_type -- SQL Server 2016 (13.x) or later. 0 = Not generated, 1 = AS_ROW_START, 2 = AS_ROW_END
-	
+    ss.schema_id,
+    st.object_id AS table_object_id,
+    sv.object_id AS view_object_id,
+    
+    sc.is_identity,
+    sc.is_rowguidcol,
+    sc.is_computed, -- Computed columns are read-only, do not confuse it with a column with a DEFAULT expression (which can be re-assigned). See the IsStoreGenerated attribute.
+    CONVERT( tinyint, [sc].[generated_always_type] ) AS generated_always_type -- SQL Server 2016 (13.x) or later. 0 = Not generated, 1 = AS_ROW_START, 2 = AS_ROW_END
+    
 INTO
-	#Columns
+    #Columns
 FROM
-	INFORMATION_SCHEMA.COLUMNS c
+    INFORMATION_SCHEMA.COLUMNS c
 
-	INNER JOIN sys.schemas AS ss ON c.TABLE_SCHEMA = ss.[name]
-	LEFT OUTER JOIN sys.tables AS st ON st.schema_id = ss.schema_id AND st.[name] = c.TABLE_NAME
-	LEFT OUTER JOIN sys.views AS sv ON sv.schema_id = ss.schema_id AND sv.[name] = c.TABLE_NAME
-	INNER JOIN sys.all_columns AS sc ON sc.object_id = COALESCE( st.object_id, sv.object_id ) AND c.COLUMN_NAME = sc.[name]
+    INNER JOIN sys.schemas AS ss ON c.TABLE_SCHEMA = ss.[name]
+    LEFT OUTER JOIN sys.tables AS st ON st.schema_id = ss.schema_id AND st.[name] = c.TABLE_NAME
+    LEFT OUTER JOIN sys.views AS sv ON sv.schema_id = ss.schema_id AND sv.[name] = c.TABLE_NAME
+    INNER JOIN sys.all_columns AS sc ON sc.object_id = COALESCE( st.object_id, sv.object_id ) AND c.COLUMN_NAME = sc.[name]
 
 WHERE
-	C.TABLE_NAME NOT IN ('EdmMetadata', '__MigrationHistory', '__RefactorLog', 'sysdiagrams')
+    C.TABLE_NAME NOT IN ('EdmMetadata', '__MigrationHistory', '__RefactorLog', 'sysdiagrams')
 
 
 CREATE NONCLUSTERED INDEX IX_EfPoco_Columns
-	ON dbo.#Columns (TABLE_NAME)
-	INCLUDE (
-		TABLE_SCHEMA,COLUMN_NAME,ORDINAL_POSITION,COLUMN_DEFAULT,IS_NULLABLE,DATA_TYPE,CHARACTER_MAXIMUM_LENGTH,NUMERIC_PRECISION,NUMERIC_SCALE,DATETIME_PRECISION,
-		schema_id, table_object_id, view_object_id,
-		is_identity,is_rowguidcol,is_computed,generated_always_type
-	);
-	
+    ON dbo.#Columns (TABLE_NAME)
+    INCLUDE (
+        TABLE_SCHEMA,COLUMN_NAME,ORDINAL_POSITION,COLUMN_DEFAULT,IS_NULLABLE,DATA_TYPE,CHARACTER_MAXIMUM_LENGTH,NUMERIC_PRECISION,NUMERIC_SCALE,DATETIME_PRECISION,
+        schema_id, table_object_id, view_object_id,
+        is_identity,is_rowguidcol,is_computed,generated_always_type
+    );
+    
 --SELECT * FROM #Columns;
 
 -----------
 SELECT
-	u.TABLE_SCHEMA,
-	u.TABLE_NAME,
-	u.COLUMN_NAME,
-	u.ORDINAL_POSITION
+    u.TABLE_SCHEMA,
+    u.TABLE_NAME,
+    u.COLUMN_NAME,
+    u.ORDINAL_POSITION
 INTO
-	#PrimaryKeys
+    #PrimaryKeys
 FROM
-	INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
-	INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON
-		u.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = tc.CONSTRAINT_SCHEMA COLLATE DATABASE_DEFAULT
-		AND
-		u.TABLE_NAME = tc.TABLE_NAME
-		AND
-		u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+    INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+    INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON
+        u.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = tc.CONSTRAINT_SCHEMA COLLATE DATABASE_DEFAULT
+        AND
+        u.TABLE_NAME = tc.TABLE_NAME
+        AND
+        u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
 WHERE
-	CONSTRAINT_TYPE = 'PRIMARY KEY';
+    CONSTRAINT_TYPE = 'PRIMARY KEY';
 
 SELECT DISTINCT
-	u.TABLE_SCHEMA,
-	u.TABLE_NAME,
-	u.COLUMN_NAME
+    u.TABLE_SCHEMA,
+    u.TABLE_NAME,
+    u.COLUMN_NAME
 INTO
-	#ForeignKeys
+    #ForeignKeys
 FROM
-	INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
-	INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON
-		u.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = tc.CONSTRAINT_SCHEMA COLLATE DATABASE_DEFAULT
-		AND
-		u.TABLE_NAME = tc.TABLE_NAME
-		AND
-		u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+    INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+    INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON
+        u.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = tc.CONSTRAINT_SCHEMA COLLATE DATABASE_DEFAULT
+        AND
+        u.TABLE_NAME = tc.TABLE_NAME
+        AND
+        u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
 WHERE
-	CONSTRAINT_TYPE = 'FOREIGN KEY';
+    CONSTRAINT_TYPE = 'FOREIGN KEY';
 
 --------------------------
 
 SELECT
-	c.TABLE_SCHEMA AS SchemaName,
-	c.TABLE_NAME AS TableName,
-	t.TABLE_TYPE AS TableType,
-	CONVERT( tinyint, ISNULL( tt.temporal_type, 0 ) ) AS TableTemporalType,
+    c.TABLE_SCHEMA AS SchemaName,
+    c.TABLE_NAME AS TableName,
+    t.TABLE_TYPE AS TableType,
+    CONVERT( tinyint, ISNULL( tt.temporal_type, 0 ) ) AS TableTemporalType,
 
-	c.ORDINAL_POSITION AS Ordinal,
-	c.COLUMN_NAME AS ColumnName,
-	c.is_nullable AS IsNullable,
-	DATA_TYPE AS TypeName,
-	ISNULL(CHARACTER_MAXIMUM_LENGTH, 0) AS [MaxLength],
-	CAST(ISNULL(NUMERIC_PRECISION, 0) AS INT) AS [Precision],
-	ISNULL(COLUMN_DEFAULT, '') AS [Default],
-	CAST(ISNULL(DATETIME_PRECISION, 0) AS INT) AS DateTimePrecision,
-	ISNULL(NUMERIC_SCALE, 0) AS Scale,
+    c.ORDINAL_POSITION AS Ordinal,
+    c.COLUMN_NAME AS ColumnName,
+    c.is_nullable AS IsNullable,
+    DATA_TYPE AS TypeName,
+    ISNULL(CHARACTER_MAXIMUM_LENGTH, 0) AS [MaxLength],
+    CAST(ISNULL(NUMERIC_PRECISION, 0) AS INT) AS [Precision],
+    ISNULL(COLUMN_DEFAULT, '') AS [Default],
+    CAST(ISNULL(DATETIME_PRECISION, 0) AS INT) AS DateTimePrecision,
+    ISNULL(NUMERIC_SCALE, 0) AS Scale,
 
-	c.is_identity AS IsIdentity,
-	c.is_rowguidcol AS IsRowGuid,
-	c.is_computed AS IsComputed,
-	c.generated_always_type AS GeneratedAlwaysType,
+    c.is_identity AS IsIdentity,
+    c.is_rowguidcol AS IsRowGuid,
+    c.is_computed AS IsComputed,
+    c.generated_always_type AS GeneratedAlwaysType,
 
-	CONVERT( bit,
-		CASE WHEN
-			c.is_identity = 1 OR
-			c.is_rowguidcol = 1 OR
-			c.is_computed = 1 OR
-			c.generated_always_type <> 0 OR
-			c.DATA_TYPE IN ( 'rowversion', 'timestamp' ) OR
-			( c.DATA_TYPE = 'uniqueidentifier' AND c.COLUMN_DEFAULT LIKE '%newsequentialid%' )
-			THEN 1
-		ELSE
-			0
-		END
-	) AS IsStoreGenerated,
-	
-	CONVERT( bit, ISNULL( pk.ORDINAL_POSITION, 0 ) ) AS PrimaryKey,
-	ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
-	CONVERT( bit, CASE WHEN fk.COLUMN_NAME IS NOT NULL THEN 1 ELSE 0 END ) AS IsForeignKey
+    CONVERT( bit,
+        CASE WHEN
+            c.is_identity = 1 OR
+            c.is_rowguidcol = 1 OR
+            c.is_computed = 1 OR
+            c.generated_always_type <> 0 OR
+            c.DATA_TYPE IN ( 'rowversion', 'timestamp' ) OR
+            ( c.DATA_TYPE = 'uniqueidentifier' AND c.COLUMN_DEFAULT LIKE '%newsequentialid%' )
+            THEN 1
+        ELSE
+            0
+        END
+    ) AS IsStoreGenerated,
+    
+    CONVERT( bit, ISNULL( pk.ORDINAL_POSITION, 0 ) ) AS PrimaryKey,
+    ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
+    CONVERT( bit, CASE WHEN fk.COLUMN_NAME IS NOT NULL THEN 1 ELSE 0 END ) AS IsForeignKey
 
 FROM
-	
-	#Columns c
-	
-	LEFT OUTER JOIN #PrimaryKeys pk ON
-		c.TABLE_SCHEMA = pk.TABLE_SCHEMA AND
-		c.TABLE_NAME   = pk.TABLE_NAME AND
-		c.COLUMN_NAME  = pk.COLUMN_NAME
+    
+    #Columns c
+    
+    LEFT OUTER JOIN #PrimaryKeys pk ON
+        c.TABLE_SCHEMA = pk.TABLE_SCHEMA AND
+        c.TABLE_NAME   = pk.TABLE_NAME AND
+        c.COLUMN_NAME  = pk.COLUMN_NAME
 
-	LEFT OUTER JOIN #ForeignKeys fk ON
-		c.TABLE_SCHEMA = fk.TABLE_SCHEMA AND
-		c.TABLE_NAME   = fk.TABLE_NAME AND
-		c.COLUMN_NAME  = fk.COLUMN_NAME
-	
-	INNER JOIN INFORMATION_SCHEMA.TABLES t ON
-		c.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = t.TABLE_SCHEMA COLLATE DATABASE_DEFAULT AND
-		c.TABLE_NAME   COLLATE DATABASE_DEFAULT = t.TABLE_NAME   COLLATE DATABASE_DEFAULT
+    LEFT OUTER JOIN #ForeignKeys fk ON
+        c.TABLE_SCHEMA = fk.TABLE_SCHEMA AND
+        c.TABLE_NAME   = fk.TABLE_NAME AND
+        c.COLUMN_NAME  = fk.COLUMN_NAME
+    
+    INNER JOIN INFORMATION_SCHEMA.TABLES t ON
+        c.TABLE_SCHEMA COLLATE DATABASE_DEFAULT = t.TABLE_SCHEMA COLLATE DATABASE_DEFAULT AND
+        c.TABLE_NAME   COLLATE DATABASE_DEFAULT = t.TABLE_NAME   COLLATE DATABASE_DEFAULT
 
-	LEFT OUTER JOIN
-	(
-		SELECT
-			st.object_id,
-			[st].[temporal_type] AS temporal_type
-		FROM
-			sys.tables AS st
-	) AS tt ON c.table_object_id = tt.object_id
+    LEFT OUTER JOIN
+    (
+        SELECT
+            st.object_id,
+            [st].[temporal_type] AS temporal_type
+        FROM
+            sys.tables AS st
+    ) AS tt ON c.table_object_id = tt.object_id
 
 ORDER BY
-	c.TABLE_SCHEMA,
-	c.TABLE_NAME,
-	c.ORDINAL_POSITION;
+    c.TABLE_SCHEMA,
+    c.TABLE_NAME,
+    c.ORDINAL_POSITION;
 ";
 
         private const string SynonymTableSQLSetup = @"
@@ -1864,77 +1864,77 @@ IF OBJECT_ID('tempdb..#SynonymTargets') IS NOT NULL DROP TABLE #SynonymTargets;
 -- Synonyms
 -- Create the #SynonymDetails temp table structure for later use
 SELECT TOP (0)
-	sc.name AS SchemaName,
-	sn.name AS TableName,
-	'SN' AS TableType,
-	COLUMNPROPERTY(c.object_id, c.name, 'ordinal') AS Ordinal,
-	c.name AS ColumnName,
-	c.is_nullable AS IsNullable,
-	ISNULL(TYPE_NAME(c.system_type_id), t.name) AS TypeName,
-	ISNULL(COLUMNPROPERTY(c.object_id, c.name, 'charmaxlen'), 0) AS MaxLength,
-	CAST(ISNULL(CONVERT(TINYINT, CASE WHEN c.system_type_id IN (48, 52, 56, 59, 60, 62, 106, 108, 122, 127) THEN c.precision END), 0) AS INT) AS Precision,
-	ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '') AS [Default],
-	CAST(ISNULL(CONVERT(SMALLINT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN ODBCSCALE(c.system_type_id, c.scale) END), 0) AS INT) AS DateTimePrecision,
-	ISNULL(CONVERT(INT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN NULL ELSE ODBCSCALE(c.system_type_id, c.scale) END), 0) AS Scale,
-	CAST(COLUMNPROPERTY(OBJECT_ID(sn.base_object_name), c.NAME, 'IsIdentity') AS BIT) AS IsIdentity,
-	CAST(CASE
-		WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'IsIdentity') = 1 THEN 1
-		WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'IsComputed') = 1 THEN 1
-		WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'GeneratedAlwaysType') > 0 THEN 1
-		WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = 'TIMESTAMP' THEN 1
-		WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = 'UNIQUEIDENTIFIER' AND LOWER(ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '')) LIKE '%newsequentialid%' THEN 1
-		ELSE 0
-	END AS BIT) AS IsStoreGenerated,
-	CAST(CASE WHEN pk.ORDINAL_POSITION IS NULL THEN 0 ELSE 1 END AS BIT) AS PrimaryKey,
-	ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
-	CAST(CASE WHEN fk.COLUMN_NAME IS NULL THEN 0 ELSE 1 END AS BIT) AS IsForeignKey
+    sc.name AS SchemaName,
+    sn.name AS TableName,
+    'SN' AS TableType,
+    COLUMNPROPERTY(c.object_id, c.name, 'ordinal') AS Ordinal,
+    c.name AS ColumnName,
+    c.is_nullable AS IsNullable,
+    ISNULL(TYPE_NAME(c.system_type_id), t.name) AS TypeName,
+    ISNULL(COLUMNPROPERTY(c.object_id, c.name, 'charmaxlen'), 0) AS MaxLength,
+    CAST(ISNULL(CONVERT(TINYINT, CASE WHEN c.system_type_id IN (48, 52, 56, 59, 60, 62, 106, 108, 122, 127) THEN c.precision END), 0) AS INT) AS Precision,
+    ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '') AS [Default],
+    CAST(ISNULL(CONVERT(SMALLINT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN ODBCSCALE(c.system_type_id, c.scale) END), 0) AS INT) AS DateTimePrecision,
+    ISNULL(CONVERT(INT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN NULL ELSE ODBCSCALE(c.system_type_id, c.scale) END), 0) AS Scale,
+    CAST(COLUMNPROPERTY(OBJECT_ID(sn.base_object_name), c.NAME, 'IsIdentity') AS BIT) AS IsIdentity,
+    CAST(CASE
+        WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'IsIdentity') = 1 THEN 1
+        WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'IsComputed') = 1 THEN 1
+        WHEN COLUMNPROPERTY(OBJECT_ID(QUOTENAME(sc.NAME) + '.' + QUOTENAME(o.NAME)), c.NAME, 'GeneratedAlwaysType') > 0 THEN 1
+        WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = 'TIMESTAMP' THEN 1
+        WHEN ISNULL(TYPE_NAME(c.system_type_id), t.NAME) = 'UNIQUEIDENTIFIER' AND LOWER(ISNULL(CONVERT(NVARCHAR(4000), OBJECT_DEFINITION(c.default_object_id)), '')) LIKE '%newsequentialid%' THEN 1
+        ELSE 0
+    END AS BIT) AS IsStoreGenerated,
+    CAST(CASE WHEN pk.ORDINAL_POSITION IS NULL THEN 0 ELSE 1 END AS BIT) AS PrimaryKey,
+    ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
+    CAST(CASE WHEN fk.COLUMN_NAME IS NULL THEN 0 ELSE 1 END AS BIT) AS IsForeignKey
 INTO
-	#SynonymDetails
+    #SynonymDetails
 FROM
-	sys.synonyms sn
-	INNER JOIN sys.COLUMNS c ON c.[object_id] = OBJECT_ID(sn.base_object_name)
-	INNER JOIN sys.schemas sc ON sc.[schema_id] = sn.[schema_id]
-	LEFT JOIN sys.types t ON c.user_type_id = t.user_type_id
-	INNER JOIN sys.objects o ON c.[object_id] = o.[object_id]
-	LEFT OUTER JOIN
-	(
-		SELECT
-			u.TABLE_SCHEMA,
+    sys.synonyms sn
+    INNER JOIN sys.COLUMNS c ON c.[object_id] = OBJECT_ID(sn.base_object_name)
+    INNER JOIN sys.schemas sc ON sc.[schema_id] = sn.[schema_id]
+    LEFT JOIN sys.types t ON c.user_type_id = t.user_type_id
+    INNER JOIN sys.objects o ON c.[object_id] = o.[object_id]
+    LEFT OUTER JOIN
+    (
+        SELECT
+            u.TABLE_SCHEMA,
             u.TABLE_NAME,
             u.COLUMN_NAME,
             u.ORDINAL_POSITION
         FROM 
-			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+            INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
             INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND u.TABLE_NAME = tc.TABLE_NAME AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
         WHERE
-			CONSTRAINT_TYPE = 'PRIMARY KEY'
-	) pk
+            CONSTRAINT_TYPE = 'PRIMARY KEY'
+    ) pk
         ON sc.NAME = pk.TABLE_SCHEMA AND sn.name = pk.TABLE_NAME AND c.name = pk.COLUMN_NAME
     
-	LEFT OUTER JOIN
-	(
-		SELECT DISTINCT
-			u.TABLE_SCHEMA,
-			u.TABLE_NAME,
-			u.COLUMN_NAME
+    LEFT OUTER JOIN
+    (
+        SELECT DISTINCT
+            u.TABLE_SCHEMA,
+            u.TABLE_NAME,
+            u.COLUMN_NAME
         FROM
-			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+            INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
             INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND u.TABLE_NAME = tc.TABLE_NAME AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
         WHERE
-			CONSTRAINT_TYPE = 'FOREIGN KEY'
-	) fk
+            CONSTRAINT_TYPE = 'FOREIGN KEY'
+    ) fk
         ON sc.NAME = fk.TABLE_SCHEMA AND sn.name = fk.TABLE_NAME AND c.name = fk.COLUMN_NAME;
 
 DECLARE @synonymDetailsQueryTemplate nvarchar(max) = 'USE [@synonmymDatabaseName];
 INSERT INTO #SynonymDetails (
-	SchemaName, TableName, TableType, TableTemporalType, Ordinal, ColumnName, IsNullable, TypeName, [MaxLength], [Precision], [Default], DateTimePrecision, Scale,
-	IsIdentity, IsRowGuid, IsComputed, GeneratedAlwaysType, IsStoreGenerated, PrimaryKey, PrimaryKeyOrdinal, IsForeignKey
+    SchemaName, TableName, TableType, TableTemporalType, Ordinal, ColumnName, IsNullable, TypeName, [MaxLength], [Precision], [Default], DateTimePrecision, Scale,
+    IsIdentity, IsRowGuid, IsComputed, GeneratedAlwaysType, IsStoreGenerated, PrimaryKey, PrimaryKeyOrdinal, IsForeignKey
 )
 SELECT
-	st.SynonymSchemaName AS SchemaName,
+    st.SynonymSchemaName AS SchemaName,
     st.SynonymName AS TableName,
     ''SN'' AS TableType,
-	CONVERT( tinyint, ISNULL( tt.temporal_type, 0 ) ) AS TableTemporalType,
+    CONVERT( tinyint, ISNULL( tt.temporal_type, 0 ) ) AS TableTemporalType,
 
     COLUMNPROPERTY(c.object_id, c.name, ''ordinal'') AS Ordinal,
     c.name AS ColumnName,
@@ -1946,104 +1946,104 @@ SELECT
     CAST(ISNULL(CONVERT(SMALLINT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN ODBCSCALE(c.system_type_id, c.scale) END), 0) AS INT) AS DateTimePrecision,
     ISNULL(CONVERT(INT, CASE WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN NULL ELSE ODBCSCALE(c.system_type_id, c.scale) END), 0) AS Scale,
 
-	c.is_identity AS IsIdentity,
-	c.is_rowguidcol AS IsRowGuid,
-	c.is_computed AS IsComputed,
-	CONVERT( tinyint, [c].[generated_always_type] ) AS GeneratedAlwaysType,
+    c.is_identity AS IsIdentity,
+    c.is_rowguidcol AS IsRowGuid,
+    c.is_computed AS IsComputed,
+    CONVERT( tinyint, [c].[generated_always_type] ) AS GeneratedAlwaysType,
 
-	CONVERT( bit, 
-		CASE
-			WHEN
-				c.is_identity = 1 OR
-				c.is_rowguidcol = 1 OR
-				c.is_computed = 1 OR
-				[c].[generated_always_type] <> 0 OR
-				c.DATA_TYPE IN ( 'rowversion', 'timestamp' ) OR
-				( c.DATA_TYPE = 'uniqueidentifier' AND c.COLUMN_DEFAULT LIKE '%newsequentialid%' )
-				THEN 1
-			ELSE 0
-		END
-	) AS IsStoreGenerated,
+    CONVERT( bit, 
+        CASE
+            WHEN
+                c.is_identity = 1 OR
+                c.is_rowguidcol = 1 OR
+                c.is_computed = 1 OR
+                [c].[generated_always_type] <> 0 OR
+                c.DATA_TYPE IN ( 'rowversion', 'timestamp' ) OR
+                ( c.DATA_TYPE = 'uniqueidentifier' AND c.COLUMN_DEFAULT LIKE '%newsequentialid%' )
+                THEN 1
+            ELSE 0
+        END
+    ) AS IsStoreGenerated,
 
     CAST(CASE WHEN pk.ORDINAL_POSITION IS NULL THEN 0  ELSE 1 END AS BIT) AS PrimaryKey,
     ISNULL(pk.ORDINAL_POSITION, 0) PrimaryKeyOrdinal,
     CAST(CASE WHEN fk.COLUMN_NAME IS NULL THEN 0 ELSE 1 END AS BIT) AS IsForeignKey
 FROM
-	#SynonymTargets st
+    #SynonymTargets st
     
-	INNER JOIN sys.columns c ON c.[object_id] = st.base_object_id
+    INNER JOIN sys.columns c ON c.[object_id] = st.base_object_id
     
-	LEFT JOIN sys.types t ON c.user_type_id = t.user_type_id
+    LEFT JOIN sys.types t ON c.user_type_id = t.user_type_id
     
-	INNER JOIN sys.objects o ON c.[object_id] = o.[object_id]
+    INNER JOIN sys.objects o ON c.[object_id] = o.[object_id]
     
-	LEFT OUTER JOIN
-	(
-		SELECT
-			u.TABLE_SCHEMA,
-			u.TABLE_NAME,
-			u.COLUMN_NAME,
-			u.ORDINAL_POSITION
-		FROM
-			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
-			INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND u.TABLE_NAME = tc.TABLE_NAME AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
-		WHERE
-			CONSTRAINT_TYPE = ''PRIMARY KEY''
+    LEFT OUTER JOIN
+    (
+        SELECT
+            u.TABLE_SCHEMA,
+            u.TABLE_NAME,
+            u.COLUMN_NAME,
+            u.ORDINAL_POSITION
+        FROM
+            INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+            INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND u.TABLE_NAME = tc.TABLE_NAME AND u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+        WHERE
+            CONSTRAINT_TYPE = ''PRIMARY KEY''
     ) AS pk ON
-		st.SchemaName = pk.TABLE_SCHEMA AND
-		st.ObjectName = pk.TABLE_NAME AND
-		c.name        = pk.COLUMN_NAME
+        st.SchemaName = pk.TABLE_SCHEMA AND
+        st.ObjectName = pk.TABLE_NAME AND
+        c.name        = pk.COLUMN_NAME
     
-	LEFT OUTER JOIN
-	(
+    LEFT OUTER JOIN
+    (
         SELECT DISTINCT
             u.TABLE_SCHEMA,
             u.TABLE_NAME,
             u.COLUMN_NAME
         FROM
-			INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
+            INFORMATION_SCHEMA.KEY_COLUMN_USAGE u
             INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ON
-				u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND
-				u.TABLE_NAME = tc.TABLE_NAME AND
-				u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+                u.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA AND
+                u.TABLE_NAME = tc.TABLE_NAME AND
+                u.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
         WHERE
-			CONSTRAINT_TYPE = ''FOREIGN KEY''
+            CONSTRAINT_TYPE = ''FOREIGN KEY''
     ) AS fk ON
-		st.SchemaName = fk.TABLE_SCHEMA AND
-		st.ObjectName = fk.TABLE_NAME AND
-		c.name = fk.COLUMN_NAME
+        st.SchemaName = fk.TABLE_SCHEMA AND
+        st.ObjectName = fk.TABLE_NAME AND
+        c.name = fk.COLUMN_NAME
 
-	LEFT OUTER JOIN
-	(
-		SELECT
-			st.object_id,
-			[st].[temporal_type] AS temporal_type
-		FROM
-			sys.tables AS st
-	) AS tt ON c.object_id = tt.object_id
+    LEFT OUTER JOIN
+    (
+        SELECT
+            st.object_id,
+            [st].[temporal_type] AS temporal_type
+        FROM
+            sys.tables AS st
+    ) AS tt ON c.object_id = tt.object_id
 
 WHERE
-	st.DatabaseName = @synonmymDatabaseName;
+    st.DatabaseName = @synonmymDatabaseName;
 '
 
 -- Pull details about the synonym target from each database being referenced
 SELECT
-	sc.name AS SynonymSchemaName,
-	sn.name AS SynonymName,
-	sn.object_id,
-	sn.base_object_name,
-	OBJECT_ID(sn.base_object_name) AS base_object_id,
-	PARSENAME(sn.base_object_name, 1) AS ObjectName,
-	ISNULL(PARSENAME(sn.base_object_name, 2), sc.name) AS SchemaName,
-	ISNULL(PARSENAME(sn.base_object_name, 3), DB_NAME()) AS DatabaseName,
-	PARSENAME(sn.base_object_name, 4) AS ServerName
+    sc.name AS SynonymSchemaName,
+    sn.name AS SynonymName,
+    sn.object_id,
+    sn.base_object_name,
+    OBJECT_ID(sn.base_object_name) AS base_object_id,
+    PARSENAME(sn.base_object_name, 1) AS ObjectName,
+    ISNULL(PARSENAME(sn.base_object_name, 2), sc.name) AS SchemaName,
+    ISNULL(PARSENAME(sn.base_object_name, 3), DB_NAME()) AS DatabaseName,
+    PARSENAME(sn.base_object_name, 4) AS ServerName
 INTO
-	#SynonymTargets
+    #SynonymTargets
 FROM
-	sys.synonyms sn
+    sys.synonyms sn
     INNER JOIN sys.schemas sc ON sc.schema_id = sn.schema_id
 WHERE
-	ISNULL(PARSENAME(sn.base_object_name, 4), @@SERVERNAME) = @@SERVERNAME; -- Only populate info from current server
+    ISNULL(PARSENAME(sn.base_object_name, 4), @@SERVERNAME) = @@SERVERNAME; -- Only populate info from current server
 
 -- Loop through synonyms and populate #SynonymDetails
 DECLARE @synonmymDatabaseName sysname = (SELECT TOP (1) DatabaseName FROM #SynonymTargets)
@@ -2063,32 +2063,32 @@ SET NOCOUNT OFF;
 UNION
 -- Synonyms
 SELECT
-	SchemaName,
-	TableName,
-	TableType,
-	CONVERT( tinyint, 0 ) AS TableTemporalType,
+    SchemaName,
+    TableName,
+    TableType,
+    CONVERT( tinyint, 0 ) AS TableTemporalType,
 
-	Ordinal,
-	ColumnName,
-	IsNullable,
-	TypeName,
-	[MaxLength],
-	[Precision],
+    Ordinal,
+    ColumnName,
+    IsNullable,
+    TypeName,
+    [MaxLength],
+    [Precision],
     [Default],
-	DateTimePrecision,
-	Scale,
+    DateTimePrecision,
+    Scale,
 
-	IsIdentity,
-	IsRowGuid,
-	IsComputed,
-	GeneratedAlwaysType,
+    IsIdentity,
+    IsRowGuid,
+    IsComputed,
+    GeneratedAlwaysType,
 
-	IsStoreGenerated,
-	PrimaryKey,
-	PrimaryKeyOrdinal,
-	IsForeignKey
+    IsStoreGenerated,
+    PrimaryKey,
+    PrimaryKeyOrdinal,
+    IsForeignKey
 FROM
-	#SynonymDetails";
+    #SynonymDetails";
 
             private const string ForeignKeySQL = @"
 SELECT  fkData.FK_Table,
@@ -2265,7 +2265,7 @@ FROM    [__ExtendedProperties]";
 SELECT  '' AS SchemaName,
     c.TABLE_NAME AS TableName,
     'BASE TABLE' AS TableType,
-	CONVERT( tinyint, 0 ) AS TableTemporalType,
+    CONVERT( tinyint, 0 ) AS TableTemporalType,
     c.ORDINAL_POSITION AS Ordinal,
     c.COLUMN_NAME AS ColumnName,
     CAST(CASE WHEN c.IS_NULLABLE = N'YES' THEN 1 ELSE 0 END AS BIT) AS IsNullable,
@@ -2277,26 +2277,26 @@ SELECT  '' AS SchemaName,
     CASE WHEN c.DATA_TYPE = N'datetime' THEN 0 WHEN c.NUMERIC_SCALE IS NOT NULL THEN c.NUMERIC_SCALE ELSE 0 END AS Scale,
 
     CAST(CASE WHEN c.AUTOINC_INCREMENT > 0 THEN 1 ELSE 0 END AS BIT) AS IsIdentity,
-	0 AS IsRowGuid,
-	0 AS IsComputed,
-	CONVERT( tinyint, 0 ) AS GeneratedAlwaysType,
+    0 AS IsRowGuid,
+    0 AS IsComputed,
+    CONVERT( tinyint, 0 ) AS GeneratedAlwaysType,
     CAST(CASE WHEN c.DATA_TYPE = N'rowversion' THEN 1 ELSE 0 END AS BIT) AS IsStoreGenerated,
     CAST(CASE WHEN u.TABLE_NAME IS NULL THEN 0 ELSE 1 END AS BIT) AS PrimaryKey,
     0 AS PrimaryKeyOrdinal,
     CONVERT( bit, 0 ) as IsForeignKey
 FROM
-	INFORMATION_SCHEMA.COLUMNS c
+    INFORMATION_SCHEMA.COLUMNS c
     INNER JOIN INFORMATION_SCHEMA.TABLES t ON c.TABLE_NAME = t.TABLE_NAME
     LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS cons ON cons.TABLE_NAME = c.TABLE_NAME
     LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS u ON
-		cons.CONSTRAINT_NAME = u.CONSTRAINT_NAME AND
+        cons.CONSTRAINT_NAME = u.CONSTRAINT_NAME AND
         u.TABLE_NAME = c.TABLE_NAME AND
         u.COLUMN_NAME = c.COLUMN_NAME
 WHERE
-	t.TABLE_TYPE <> N'SYSTEM TABLE' AND
-	cons.CONSTRAINT_TYPE = 'PRIMARY KEY'
+    t.TABLE_TYPE <> N'SYSTEM TABLE' AND
+    cons.CONSTRAINT_TYPE = 'PRIMARY KEY'
 ORDER BY
-	c.TABLE_NAME,
+    c.TABLE_NAME,
     c.COLUMN_NAME,
     c.ORDINAL_POSITION";
 
@@ -2683,13 +2683,13 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             else
                 Cmd.CommandTimeout = Settings.CommandTimeout;
 
-			if (!Settings.TemporalTableSupport)
-			{
-				Cmd.CommandText = Cmd.CommandText
-					.Replace("[sc].[generated_always_type]", "0" )
-					.Replace("[c].[generated_always_type]", "0" )
-					.Replace("[st].[temporal_type]", "0" );
-			}
+            if (!Settings.TemporalTableSupport)
+            {
+                Cmd.CommandText = Cmd.CommandText
+                    .Replace("[sc].[generated_always_type]", "0" )
+                    .Replace("[c].[generated_always_type]", "0" )
+                    .Replace("[st].[temporal_type]", "0" );
+            }
 
             using(var rdr = Cmd.ExecuteReader())
             {
@@ -2712,12 +2712,12 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                         table = result.Find(x => x.Name == tableName && x.Schema == schema);
                         if(table == null)
                         {
-							table = new Table
+                            table = new Table
                             {
                                 Name = tableName,
                                 Schema = schema,
                                 IsView = string.Compare(rdr["TableType"].ToString().Trim(), "View", StringComparison.OrdinalIgnoreCase) == 0,
-								TemporalType = (TableTemporalType)(Byte)rdr["TableTemporalType"],
+                                TemporalType = (TableTemporalType)(Byte)rdr["TableTemporalType"],
 
                                 // Will be set later
                                 HasForeignKey = false,
@@ -3381,37 +3381,37 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             string  typename      = rdr["TypeName"].ToString().Trim().ToLower();
             Int32   rdrScale      = (int)rdr["Scale"];
 
-			Boolean rdrIsNullable = (Boolean)rdr["IsNullable"];
-			Int32   rdrMaxLength  = (int)rdr["MaxLength"];
-			Int32   rdrDtp        = (int)rdr["DateTimePrecision"];
-			Int32   rdrPrecision  = (int)rdr["Precision"];
-			Boolean rdrIsIdentity = (Boolean)rdr["IsIdentity"];
-			Boolean rdrIsComputed = (Boolean)rdr["IsComputed"];
-			Boolean rdrIsRowGuid  = (Boolean)rdr["IsRowGuid"];
-			Byte    rdrGat        = (Byte)rdr["GeneratedAlwaysType"];
-			Boolean rdrIsg        = (Boolean)rdr["IsStoreGenerated"];
-			Int32   rdrPko        = (int)rdr["PrimaryKeyOrdinal"];
-			Boolean rdrIsPk       = (Boolean)rdr["PrimaryKey"];
-			Boolean rdrIsFk       = (Boolean)rdr["IsForeignKey"];
+            Boolean rdrIsNullable = (Boolean)rdr["IsNullable"];
+            Int32   rdrMaxLength  = (int)rdr["MaxLength"];
+            Int32   rdrDtp        = (int)rdr["DateTimePrecision"];
+            Int32   rdrPrecision  = (int)rdr["Precision"];
+            Boolean rdrIsIdentity = (Boolean)rdr["IsIdentity"];
+            Boolean rdrIsComputed = (Boolean)rdr["IsComputed"];
+            Boolean rdrIsRowGuid  = (Boolean)rdr["IsRowGuid"];
+            Byte    rdrGat        = (Byte)rdr["GeneratedAlwaysType"];
+            Boolean rdrIsg        = (Boolean)rdr["IsStoreGenerated"];
+            Int32   rdrPko        = (int)rdr["PrimaryKeyOrdinal"];
+            Boolean rdrIsPk       = (Boolean)rdr["PrimaryKey"];
+            Boolean rdrIsFk       = (Boolean)rdr["IsForeignKey"];
 
             var col = new Column
             {
-				Ordinal             = (int)rdr["Ordinal"],
-				Name                = rdr["ColumnName"].ToString().Trim(),
-				IsNullable          = rdrIsNullable,
-				PropertyType        = GetPropertyType(typename),
-				SqlPropertyType     = typename,
+                Ordinal             = (int)rdr["Ordinal"],
+                Name                = rdr["ColumnName"].ToString().Trim(),
+                IsNullable          = rdrIsNullable,
+                PropertyType        = GetPropertyType(typename),
+                SqlPropertyType     = typename,
                 MaxLength           = rdrMaxLength,
-				Precision           = rdrPrecision,
-				Default             = rdr["Default"].ToString().Trim(),
-				DateTimePrecision   = rdrDtp,
+                Precision           = rdrPrecision,
+                Default             = rdr["Default"].ToString().Trim(),
+                DateTimePrecision   = rdrDtp,
                 Scale               = rdrScale,
 
                 IsIdentity          = rdrIsIdentity,
-				IsRowGuid           = rdrIsRowGuid,
-				IsComputed          = rdrIsComputed,
-				GeneratedAlwaysType = (ColumnGeneratedAlwaysType)rdrGat,
-				IsStoreGenerated    = rdrIsg,
+                IsRowGuid           = rdrIsRowGuid,
+                IsComputed          = rdrIsComputed,
+                GeneratedAlwaysType = (ColumnGeneratedAlwaysType)rdrGat,
+                IsStoreGenerated    = rdrIsg,
 
                 IsPrimaryKey        = rdrIsPk,
                 PrimaryKeyOrdinal   = rdrPko,
@@ -3742,19 +3742,19 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
         public bool IsClustered;
     }
 
-	public enum TableTemporalType
-	{
-		None,
-		Verioned,
-		History
-	}
+    public enum TableTemporalType
+    {
+        None,
+        Verioned,
+        History
+    }
 
-	public enum ColumnGeneratedAlwaysType
-	{
-		NotApplicable = 0,
-		AsRowStart = 1,
-		AsRowEnd = 2
-	}
+    public enum ColumnGeneratedAlwaysType
+    {
+        NotApplicable = 0,
+        AsRowStart = 1,
+        AsRowEnd = 2
+    }
 
     public class Table
     {
@@ -3770,7 +3770,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
         public bool HasForeignKey;
         public bool HasNullableColumns;
         public bool HasPrimaryKey;
-		public TableTemporalType TemporalType;
+        public TableTemporalType TemporalType;
 
         public List<Column> Columns;
         public List<PropertyAndComments> ReverseNavigationProperty;


### PR DESCRIPTION
This one isn't as well-tested as my previous contributions because of an urgency in production - but you can take your time with validating this.

This change adds support for Temporal Tables in a way that's backwards-compatible with older versions of SQL Server (you need to opt-in by setting `Settings.TemporalTableSupport = true` and when it's `false` it does a `String.Replace` to replace the new `sys.columns` attributes with constants.

The change exposes the `Table.TemporalType` and `Column.GeneratedAlwaysType` values to the `.tt` file. It should also automatically set those columns to `HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity)` as per the advice in this QA: https://stackoverflow.com/questions/40742142/entity-framework-not-working-with-temporal-table - I also updated the definition of `IsComputed` and return more properties from `sys.columns`.

I also updated the SQL code for SQL-CE and "with synonyms" but that's untested.