### PR TITLE
Allow pulling base functions from inherited interface

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -35,6 +35,7 @@
     Settings.UseDataAnnotationsWithFluent = false; // If true, then non-Entity Framework-specific DataAnnotations (like [Required] and [StringLength]) will be applied to Entities even if UseDataAnnotations is false.
     Settings.UsePropertyInitializers = false; // Removes POCO constructor and instead uses C# 6 property initialisers to set defaults
     Settings.UseLazyLoading = true; // Marks all navigation properties as virtual or not, to support or disable EF Lazy Loading feature
+    Settings.UseInheritedBaseInterfaceFunctions = false; // If true, the main DBContext interface functions will come from the DBContextInterfaceBaseClasses and not generated. If false, the functions will be generated.
     Settings.IncludeComments = CommentsStyle.AtEndOfField; // Adds comments to the generated code
     Settings.IncludeExtendedPropertyComments = CommentsStyle.InSummaryBlock; // Adds extended properties as comments to the generated code
     Settings.IncludeConnectionSettingComments = true; // Add comments describing connection settings used to generate file

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -128,6 +128,7 @@
         public static Dictionary<string, string> StoredProcedureReturnTypes = new Dictionary<string, string>();
         public static Regex ColumnFilterExclude;
         public static bool UseLazyLoading;
+        public static bool UseInheritedBaseInterfaceFunctions = false;
         public static string[] FilenameSearchOrder;
         public static string[] AdditionalNamespaces;
         public static string[] AdditionalContextInterfaceItems;

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -96,6 +96,7 @@ else
 { #>
         <#=s #>
 <# } #>
+<# if (!Settings.UseInheritedBaseInterfaceFunctions) { #>
         int SaveChanges();
 <# if (Settings.IsSupportedFrameworkVersion("4.5")) { #>
         System.Threading.Tasks.Task<int> SaveChangesAsync();
@@ -110,6 +111,7 @@ else
         System.Data.Entity.DbSet Set(System.Type entityType);
         System.Data.Entity.DbSet<TEntity> Set<TEntity>() where TEntity : class;
         string ToString();
+<# } #>
 <# if (Settings.StoredProcs.Any()) { #>
 
         // Stored Procedures


### PR DESCRIPTION
When setting Settings.DbContextInterfaceBaseClasses to an interface that already had functions such as Set, the library would give messages about wanting to add new to override the functions from the base.   Adding Settings.UseInheritedBaseInterfaceFunctions would allow the user to not generate those functions if they are already defined in the base class.