### PR TITLE
Resolves #465 for many to many relationships to rename the property names

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -249,6 +249,25 @@
         return name;
     };
 
+    // Mapping Table renaming *********************************************************************************************************************
+    // By default, name of the properties created relate to the table the foreign key points to and not the mapping table.
+    // Use the following function to rename the properties created by ManytoMany relationship tables especially if you have 2 relationships between the same tables.
+    // Example:
+    Settings.MappingTableRename = (string mappingtable, string tablename, string entityname) =>
+    {
+
+       // Examples:
+       // If you have two mapping tables such as one being UserRequiredSkills snd one being UserOptionalSkills, this would change the name of one property
+       // if (mappingtable == "UserRequiredSkills" and tablename == "User")
+       //    return "RequiredSkills";
+
+       // or if you want to give the same property name on both classes
+       // if (mappingtable == "UserRequiredSkills")
+       //    return "UserRequiredSkills";
+
+        return entityname;
+    };
+
     // Column modification*****************************************************************************************************************
     // Use the following list to replace column byte types with Enums.
     // As long as the type can be mapped to your new type, all is well.

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -135,6 +135,7 @@
         public static string[] AdditionalForeignKeysDataAnnotations;
         public static string ConfigFilePath;
         public static Func<string, string, bool, string> TableRename;
+        public static Func<string, string, string, string> MappingTableRename;
         public static Func<StoredProcedure, string> StoredProcedureRename;
         public static Func<string, StoredProcedure, string> StoredProcedureReturnModelRename;
         public static Func<Column, Table, Column> UpdateColumn;
@@ -4133,7 +4134,9 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 return;
 
             var leftPropName  = leftTable.GetUniqueColumnName(rightTable.NameHumanCase, right, checkForFkNameClashes, false, Relationship.ManyToOne); // relationship from the mapping table to each side is Many-to-One
+            leftPropName = Settings.MappingTableRename(Name, leftTable.NameHumanCase, leftPropName);
             var rightPropName = rightTable.GetUniqueColumnName(leftTable.NameHumanCase, left, checkForFkNameClashes, false, Relationship.ManyToOne); // relationship from the mapping table to each side is Many-to-One
+            rightPropName = Settings.MappingTableRename(Name, rightTable.NameHumanCase, rightPropName);
             leftTable.AddMappingConfiguration(left, right, leftPropName, rightPropName);
 
             IsMapping = true;


### PR DESCRIPTION
Resolves #465 

This will allow manual renames for many to many relationships.  
If you have two relationships between two tables, they end up having the same property name so instead it can be renamed in the Settings.MappingTableRename function in the database.tt  