### PR TITLE
Added the ability to override the Id column with the "new" access modifier

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/Database NorthwindSqlCe40.cs
+++ b/EntityFramework.Reverse.POCO.Generator/Database NorthwindSqlCe40.cs
@@ -9,7 +9,7 @@
 // The following connection settings were used to generate this file:
 //     Configuration file:     "EntityFramework.Reverse.POCO.Generator\App.config"
 //     Connection String Name: "MyDbContextSqlCE4"
-//     Connection String:      "Data Source=C:\S\Source (open source)\EntityFramework Reverse POCO Code Generator\EntityFramework.Reverse.POCO.Generator\App_Data\NorthwindSqlCe40.sdf"
+//     Connection String:      "Data Source=C:\git\EntityFramework-Reverse-POCO-Code-First-Generator\EntityFramework.Reverse.POCO.Generator\App_Data\NorthwindSqlCe40.sdf"
 // ------------------------------------------------------------------------------------------------
 // Database Edition : SqlCE
 

--- a/EntityFramework.Reverse.POCO.Generator/Database NorthwindSqlCe40.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database NorthwindSqlCe40.tt
@@ -260,6 +260,12 @@
         //    column.OverrideModifier = true;
         // This will create: public override long id { get; set; }
 
+        // Apply the "new" override access modifier to a specific column
+        // Use when overriding the Id when the base type is object
+        // if (column.NamehumanCase == "Id")
+        //    column.NewOverrideModifier = true;
+        // This will create: public new long id { get; set; }
+
         // Perform Enum property type replacement
         var enumDefinition = Settings.EnumDefinitions.FirstOrDefault(e =>
             (e.Schema.Equals(table.Schema, StringComparison.InvariantCultureIgnoreCase)) &&

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -303,6 +303,12 @@
         //    column.OverrideModifier = true;
         // This will create: public override long id { get; set; }
 
+        // Apply the "new" override access modifier to a specific column
+        // Use when overriding the Id when the base type is object
+        // if (column.NamehumanCase == "Id")
+        //    column.NewOverrideModifier = true;
+        // This will create: public new long id { get; set; }
+
         // Perform Enum property type replacement
         var enumDefinition = Settings.EnumDefinitions.FirstOrDefault(e =>
             (e.Schema.Equals(table.Schema, StringComparison.InvariantCultureIgnoreCase)) &&

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -974,7 +974,8 @@
         public string Name; // Raw name of the column as obtained from the database
         public string NameHumanCase; // Name adjusted for C# output
         public string DisplayName;  // Name used in the data annotation [Display(Name = "<DisplayName> goes here")]
-        public bool  OverrideModifier = false; // Adds 'override' to the property declaration
+        public bool OverrideModifier = false; // Adds 'override' to the property declaration
+        public bool NewOverrideModifier = false; // Adds 'new' to the property declaration to override a base type of object
 
         public int DateTimePrecision;
         public string Default;
@@ -1067,6 +1068,10 @@
             Entity = string.Format(
                 "public {0}{1} {2} {{ get; {3}set; }}{4}{5}",
                 (OverrideModifier ? "override " : ""), WrapIfNullable(PropertyType, this), NameHumanCase, Settings.UsePrivateSetterForComputedColumns && IsComputed ? "private " : string.Empty, initialization, inlineComments
+
+            Entity = string.Format(
+            "public {0}{1} {2} {{ get; {3}set; }}{4}{5}",
+            (NewOverrideModifier ? "new " : ""), WrapIfNullable(PropertyType, this), NameHumanCase, Settings.UsePrivateSetterForComputedColumns && IsComputed ? "private " : string.Empty, initialization, inlineComments
             );
         }
 


### PR DESCRIPTION
When overriding a base class with an Id of type object, you must use the "new" access modifier instead of "override".  I added a down and dirty way to show an example of how this could work.  We inherit a base class and it includes an Id property of type object and we couldn't override it.