### PR TITLE
Add the [Required] attribute on foreign keys

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -3290,7 +3290,11 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 string fkPropName = pkTable.GetUniqueColumnName(fkTable.NameHumanCase, foreignKey, checkForFkNameClashes, fkMakePropNameSingular, Relationship.OneToMany);
 
                 var dataAnnotation = string.Empty;
-                if (Settings.UseDataAnnotations)
+                if (Settings.UseDataAnnotationsWithFluent && !Settings.UseDataAnnotations)
+                {
+                    dataAnnotation = foreignKey.IncludeRequiredAttribute ? "[Required] " : string.Empty;
+                }
+                else if (Settings.UseDataAnnotations)
                 {
                     dataAnnotation = string.Format("[ForeignKey(\"{0}\"){1}] ",
                         string.Join(", ", fkCols.Select(x => x.col.NameHumanCase).Distinct().ToArray()),


### PR DESCRIPTION
when Settings.UseDataAnnotationsWithFluent is true

Some context: the [Required] attribute must be set on foreign keys in order for OData.NET to properly generate its metadata document with nullable=false, see https://github.com/OData/WebApi/issues/690