### PR TITLE
Fix addReverseNavigationUniquePropName determination

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -3955,7 +3955,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
 
         public string GetUniqueColumnName(string tableNameHumanCase, ForeignKey foreignKey, bool checkForFkNameClashes, bool makeSingular, Relationship relationship)
         {
-            var addReverseNavigationUniquePropName = (checkForFkNameClashes || Name == foreignKey.FkTableName || (Name == foreignKey.PkTableName && foreignKey.IncludeReverseNavigation));
+            var addReverseNavigationUniquePropName = checkForFkNameClashes && (Name == foreignKey.FkTableName || (Name == foreignKey.PkTableName && foreignKey.IncludeReverseNavigation));          
             if (ReverseNavigationUniquePropName.Count == 0)
             {
                 ReverseNavigationUniquePropName.Add(NameHumanCase);


### PR DESCRIPTION
The current logic for determining whether a column / property name always checks for uniqueness even if it's not required;  when checkForFkNameClases is TRUE, then the other conditions aren't considered, specifically foreignKey.IncludeReverseNavigation. 






  

