### PR TITLE
Always add columns names to the ReverseNavigationUniquePropName array

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -3974,7 +3974,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             string col;
             if (!ReverseNavigationUniquePropNameClashes.Contains(name) && !ReverseNavigationUniquePropName.Contains(name))
             {
-                if(addReverseNavigationUniquePropName)
+                if(addReverseNavigationUniquePropName || !checkForFkNameClashes)
                 {
                     ReverseNavigationUniquePropName.Add(name);
                 }
@@ -3995,7 +3995,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     if (!ReverseNavigationUniquePropNameClashes.Contains(col) &&
                         !ReverseNavigationUniquePropName.Contains(col))
                     {
-                        if(addReverseNavigationUniquePropName)
+                        if(addReverseNavigationUniquePropName|| !checkForFkNameClashes)
                         {
                             ReverseNavigationUniquePropName.Add(col);
                         }
@@ -4013,7 +4013,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 if (!ReverseNavigationUniquePropNameClashes.Contains(col) &&
                     !ReverseNavigationUniquePropName.Contains(col))
                 {
-                    if(addReverseNavigationUniquePropName)
+                    if(addReverseNavigationUniquePropName || !checkForFkNameClashes)
                     {
                         ReverseNavigationUniquePropName.Add(col);
                     }
@@ -4029,7 +4029,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
 
             if (!ReverseNavigationUniquePropNameClashes.Contains(col) && !ReverseNavigationUniquePropName.Contains(col))
             {
-                if(addReverseNavigationUniquePropName)
+                if(addReverseNavigationUniquePropName || !checkForFkNameClashes)
                 {
                     ReverseNavigationUniquePropName.Add(col);
                 }
@@ -4045,7 +4045,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 if (ReverseNavigationUniquePropName.Contains(col))
                     continue;
 
-                if(addReverseNavigationUniquePropName)
+                if(addReverseNavigationUniquePropName || !checkForFkNameClashes)
                 {
                     ReverseNavigationUniquePropName.Add(col);
                 }


### PR DESCRIPTION
Ensure that duplicate column names are stored (and therefore checked against) when checking column / property names on the second pass.