### PR TITLE
Updated support for ReverseNavigation

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -3237,7 +3237,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
         public override void ProcessForeignKeys(List<ForeignKey> fkList, Tables tables, bool checkForFkNameClashes)
         {
             var constraints = fkList.Select(x => x.FkSchema + "." + x.ConstraintName).Distinct();
-			var doubleForeignTableRefcontraints = fkList.GroupBy(x => new { x.FkTableName, x.PkTableName }).Where(g => g.Count() > 1).SelectMany(g => g.Select(x => string.Format("{0}.{1}", x.FkSchema, x.ConstraintName))).Distinct();
+            var doubleForeignTableRefcontraints = fkList.GroupBy(x => new { x.FkTableName, x.PkTableName }).Where(g => g.Count() > 1).SelectMany(g => g.Select(x => string.Format("{0}.{1}", x.FkSchema, x.ConstraintName))).Distinct();
             foreach (var constraint in constraints)
             {
                 var foreignKeys = fkList

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.Core.ttinclude
@@ -3237,6 +3237,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
         public override void ProcessForeignKeys(List<ForeignKey> fkList, Tables tables, bool checkForFkNameClashes)
         {
             var constraints = fkList.Select(x => x.FkSchema + "." + x.ConstraintName).Distinct();
+			var doubleForeignTableRefcontraints = fkList.GroupBy(x => new { x.FkTableName, x.PkTableName }).Where(g => g.Count() > 1).SelectMany(g => g.Select(x => string.Format("{0}.{1}", x.FkSchema, x.ConstraintName))).Distinct();
             foreach (var constraint in constraints)
             {
                 var foreignKeys = fkList
@@ -3362,7 +3363,7 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                     mapKey = string.Format("\"{0}\"", firstFKCol.col.Name);
                 }
 
-                if (!Settings.UseDataAnnotations)
+                if (!Settings.UseDataAnnotations || ( doubleForeignTableRefcontraints.Any(x => x.Equals(constraint, StringComparison.InvariantCultureIgnoreCase)) && relationship == Relationship.ManyToOne))
                 {
                     List<Column> fkCols2 = fkCols.Select( c => c.col ).ToList();
 


### PR DESCRIPTION
Now ReverseNavigation is possible with  data annotations in cases where you reference the same table twice.
This situation can't be defined using data annotations so there is now an exception for fluentApi Generation

Example case:
marriage table references Person table twice (for both spouses)
When you generate ReverseNavigation for this foreign key, Entity doesn't know which collection(in person) goes to which property in marriage.
To avoid this problem it will add FluentApi definition for these edge case situations.