### PR TITLE
Add Abillity to reverse engineer database and not set the properties to the default values from the database

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
@@ -100,6 +100,7 @@
         public static bool ShowLicenseInfo                  = false; // If true, will add the licence info comment to the top of each file
         public static bool IncludeConnectionSettingComments = false; // Add comments describing connection settings used to generate file
         public static bool IncludeCodeGeneratedAttribute    = false; // If true, will include the [GeneratedCode] attribute before classes, false to remove it.
+        public static bool IncludeColumnsWithDefaults       = true;  // If true, will set properties to the default value from the database.
 
         // Create enumerations from database tables
         // List the enumeration tables you want read and generated for
@@ -3520,7 +3521,7 @@
                                         Settings.EntityClassesArePartial()
                                     ),
                 ColumnsWithDefaults = table.Columns
-                    .Where(c => c.Default != string.Empty && !c.Hidden)
+                    .Where(c => c.Default != string.Empty && !c.Hidden && Settings.IncludeColumnsWithDefaults)
                     .OrderBy(x => x.Ordinal)
                     .Select(x => new PocoColumnsWithDefaultsModel { NameHumanCase = x.NameHumanCase, Default = x.Default })
                     .ToList(),


### PR DESCRIPTION
We are having an issue whereby we have a default value in the database which is a database expression that is about 70 characters long for a column that is 30 chars in length.

The web application that uses these generated classes is now failing validation as the text is too long.

I have added a new setting, IncludeColumnsWithDefaults, to the Settings class and defaulted it to true so that, by default, it behaves as it does currently, and then changed where the ColumnsWithDefaults property is set to not return any columns if the setting is set to false.