### PR TITLE
Enhancement - Custom file footer and header text settings

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
@@ -86,6 +86,8 @@
         public static bool IncludeGeneratorVersionInCode            = false; // If true, will include the version number of the generator in the generated code
         public static List<string> AdditionalNamespaces             = new List<string>(); // To include extra namespaces, include them here. i.e. "Microsoft.AspNet.Identity.EntityFramework"
         public static List<string> AdditionalContextInterfaceItems  = new List<string>(); //  example: "void SetAutoDetectChangesEnabled(bool flag);"
+        public static List<string> AdditionalFileHeaderText         = new List<string>(); // This will put additional lines verbatim at the top of each file under the comments, 1 line per entry
+        public static List<string> AdditionalFileFooterText         = new List<string>(); // This will put additional lines verbatim at the end of each file above the // </auto-generated>, 1 line per entry
 
         // Language choices
         public static GenerationLanguage GenerationLanguage = GenerationLanguage.CSharp;
@@ -3777,6 +3779,11 @@
             if (Settings.UsePragma)
                 header.AppendLine("#pragma warning disable 1591    //  Ignore \"Missing XML Comment\" warning");
             
+            foreach (var additionalHeader in Settings.AdditionalFileHeaderText)
+            {
+                header.AppendLine(additionalHeader);
+            }
+
             Header = header.ToString();
 
             header = new StringBuilder(500);
@@ -3792,6 +3799,10 @@
             var footer = new StringBuilder(30);
             if (Settings.UseNamespace)
                 footer.AppendLine("}");
+            foreach (var additionalHeader in Settings.AdditionalFileFooterText)
+            {
+                footer.AppendLine(additionalHeader);
+            }
             footer.Append("// </auto-generated>");
             Footer = footer.ToString();
         }

--- a/Generator/Generators/FileHeaderFooter.cs
+++ b/Generator/Generators/FileHeaderFooter.cs
@@ -22,6 +22,11 @@ namespace Efrpg.Generators
             if (Settings.UsePragma)
                 header.AppendLine("#pragma warning disable 1591    //  Ignore \"Missing XML Comment\" warning");
             
+            foreach (var additionalHeader in Settings.AdditionalFileHeaderText)
+            {
+                header.AppendLine(additionalHeader);
+            }
+
             Header = header.ToString();
 
             header = new StringBuilder(500);
@@ -37,6 +42,10 @@ namespace Efrpg.Generators
             var footer = new StringBuilder(30);
             if (Settings.UseNamespace)
                 footer.AppendLine("}");
+            foreach (var additionalHeader in Settings.AdditionalFileFooterText)
+            {
+                footer.AppendLine(additionalHeader);
+            }
             footer.Append("// </auto-generated>");
             Footer = footer.ToString();
         }

--- a/Generator/Settings.cs
+++ b/Generator/Settings.cs
@@ -62,6 +62,8 @@ namespace Efrpg
         public static bool IncludeGeneratorVersionInCode            = false; // If true, will include the version number of the generator in the generated code
         public static List<string> AdditionalNamespaces             = new List<string>(); // To include extra namespaces, include them here. i.e. "Microsoft.AspNet.Identity.EntityFramework"
         public static List<string> AdditionalContextInterfaceItems  = new List<string>(); //  example: "void SetAutoDetectChangesEnabled(bool flag);"
+        public static List<string> AdditionalFileHeaderText         = new List<string>(); // This will put additional lines verbatim at the top of each file under the comments, 1 line per entry
+        public static List<string> AdditionalFileFooterText         = new List<string>(); // This will put additional lines verbatim at the end of each file above the // </auto-generated>, 1 line per entry
 
         // Language choices
         public static GenerationLanguage GenerationLanguage = GenerationLanguage.CSharp;


### PR DESCRIPTION
Adding the ability to add additional text for file header and footer that is applied to every file created

Specific use case was to allow in a multi targeted library the ability to set ifdef for NETSTANDARD or NETFRAMEWORK in every file

Could have put this as a single target framework setting and used that but thought more generic may be useful if other comments/instructions are wanted