### PR TITLE
Add schema name to table valued functions

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
@@ -17628,7 +17628,7 @@ using {{this}};{{#newline}}
     public IQueryable<{{ReturnClassName}}> {{ExecName}}({{WriteStoredProcFunctionParamsFalse}}){{#newline}}
     {{{#newline}}
         return {{QueryString}}<{{ReturnClassName}}>(){{#newline}}
-            .{{FromSql}}(""SELECT * FROM [{{Name}}]({{WriteStoredProcFunctionSqlAtParams}})""{{WriteTableValuedFunctionSqlParameterAnonymousArray}}){{#newline}}
+            .{{FromSql}}(""SELECT * FROM [{{Schema}}].[{{Name}}]({{WriteStoredProcFunctionSqlAtParams}})""{{WriteTableValuedFunctionSqlParameterAnonymousArray}}){{#newline}}
             .AsNoTracking();{{#newline}}
     }{{#newline}}
 {{/each}}

--- a/Generator/Templates/TemplateEfCore.cs
+++ b/Generator/Templates/TemplateEfCore.cs
@@ -357,7 +357,7 @@ using {{this}};{{#newline}}
     public IQueryable<{{ReturnClassName}}> {{ExecName}}({{WriteStoredProcFunctionParamsFalse}}){{#newline}}
     {{{#newline}}
         return {{QueryString}}<{{ReturnClassName}}>(){{#newline}}
-            .{{FromSql}}(""SELECT * FROM [{{Name}}]({{WriteStoredProcFunctionSqlAtParams}})""{{WriteTableValuedFunctionSqlParameterAnonymousArray}}){{#newline}}
+            .{{FromSql}}(""SELECT * FROM [{{Schema}}].[{{Name}}]({{WriteStoredProcFunctionSqlAtParams}})""{{WriteTableValuedFunctionSqlParameterAnonymousArray}}){{#newline}}
             .AsNoTracking();{{#newline}}
     }{{#newline}}
 {{/each}}

--- a/Tester.Integration.EfCore3/TableValuedFunctionTests.cs
+++ b/Tester.Integration.EfCore3/TableValuedFunctionTests.cs
@@ -43,5 +43,20 @@ namespace Tester.Integration.EfCore3
             Assert.AreEqual(123, data[0].IntValue);
             Assert.AreEqual(456, data[1].IntValue);
         }
+
+        [Test]
+        public void Standard_FunctionInNonDefaultSchemaCanBeCalled()
+        {
+            // Arrange
+            using var db = new TestDatabaseStandard.TestDbContext();
+
+            // Act
+            var data = db.CustomSchema_CsvToIntWithSchema("123,456", "").ToList();
+
+            // Assert
+            Assert.AreEqual(2, data.Count);
+            Assert.AreEqual(123, data[0].IntValue);
+            Assert.AreEqual(456, data[1].IntValue);
+        }
     }
 }

--- a/Tester.Integration.EfCore3/TestDatabase.cs
+++ b/Tester.Integration.EfCore3/TestDatabase.cs
@@ -52,6 +52,7 @@ namespace TestDatabaseStandard
 
         // Table Valued Functions
         IQueryable<CsvToIntReturnModel> CsvToInt(string array, string array2); // dbo.CsvToInt
+        IQueryable<CustomSchema_CsvToIntWithSchemaReturnModel> CustomSchema_CsvToIntWithSchema(string array, string array2); // CustomSchema.CsvToIntWithSchema
 
         // Scalar Valued Functions
         decimal UdfNetSale(int? quantity, decimal? listPrice, decimal? discount); // dbo.udfNetSale
@@ -115,6 +116,7 @@ namespace TestDatabaseStandard
 
             // Table Valued Functions
             modelBuilder.Entity<CsvToIntReturnModel>().HasNoKey();
+            modelBuilder.Entity<CustomSchema_CsvToIntWithSchemaReturnModel>().HasNoKey();
         }
 
 
@@ -162,7 +164,15 @@ namespace TestDatabaseStandard
         public IQueryable<CsvToIntReturnModel> CsvToInt(string array, string array2)
         {
             return Set<CsvToIntReturnModel>()
-                .FromSqlRaw("SELECT * FROM [CsvToInt]({0}, {1})", array, array2)
+                .FromSqlRaw("SELECT * FROM [dbo].[CsvToInt]({0}, {1})", array, array2)
+                .AsNoTracking();
+        }
+
+        // CustomSchema.CsvToIntWithSchema
+        public IQueryable<CustomSchema_CsvToIntWithSchemaReturnModel> CustomSchema_CsvToIntWithSchema(string array, string array2)
+        {
+            return Set<CustomSchema_CsvToIntWithSchemaReturnModel>()
+                .FromSqlRaw("SELECT * FROM [CustomSchema].[CsvToIntWithSchema]({0}, {1})", array, array2)
                 .AsNoTracking();
         }
 
@@ -289,6 +299,12 @@ namespace TestDatabaseStandard
         public IQueryable<CsvToIntReturnModel> CsvToInt(string array, string array2)
         {
             return new List<CsvToIntReturnModel>().AsQueryable();
+        }
+
+        // CustomSchema.CsvToIntWithSchema
+        public IQueryable<CustomSchema_CsvToIntWithSchemaReturnModel> CustomSchema_CsvToIntWithSchema(string array, string array2)
+        {
+            return new List<CustomSchema_CsvToIntWithSchemaReturnModel>().AsQueryable();
         }
 
         // Scalar Valued Functions
@@ -878,6 +894,11 @@ namespace TestDatabaseStandard
     #region Stored procedure return models
 
     public class CsvToIntReturnModel
+    {
+        public int? IntValue { get; set; }
+    }
+
+    public class CustomSchema_CsvToIntWithSchemaReturnModel
     {
         public int? IntValue { get; set; }
     }

--- a/Tester.Integration.EfCore3/TestDatabase.sql
+++ b/Tester.Integration.EfCore3/TestDatabase.sql
@@ -447,6 +447,45 @@ BEGIN
 END
 GO
 
+IF SCHEMA_ID(N'CustomSchema') IS NULL
+    EXEC (N'CREATE SCHEMA [CustomSchema];');
+GO
+
+CREATE FUNCTION [CustomSchema].[CsvToIntWithSchema]
+(
+	@array varchar(8000),
+	@array2 varchar(8000) = ''
+)
+RETURNS @IntTable TABLE(IntValue int)
+AS
+BEGIN
+	DECLARE @seperator char(1)
+	SET @seperator = ','
+
+	DECLARE @seperator_position int
+	DECLARE @array_value varchar(8000)
+
+	SET @array = @array + @seperator
+
+	WHILE PATINDEX('%,%', @array) <> 0
+	BEGIN
+		SELECT @seperator_position = PATINDEX('%,%', @array)
+		SELECT @array_value = LEFT(@array, @seperator_position - 1)
+
+		INSERT @IntTable VALUES (CAST(@array_value AS int))
+
+		SELECT @array = STUFF(@array, 1, @seperator_position, '')
+		IF LEN(@array) = 0 AND LEN(@array2) > 0
+		BEGIN
+			SET @array = @array2 + ','
+			SET @array2 = ''
+		END
+	END
+
+	RETURN
+END
+GO
+
 CREATE FUNCTION udfNetSale (@quantity INT, @list_price DEC(10, 2), @discount DEC(4, 2))
 RETURNS DEC(10, 2)
 AS


### PR DESCRIPTION
Add the schema name to the generated SQL for calling table-valued functions so that functions in the non default schema can be called.
This will also add the dbo schema name in front of functions in that schema, which is not required, but I don't think this has negative effects.