### PR TITLE
BugFix: Allowing removal of parameterless constructor

### DIFF
--- a/Generator/Templates/TemplateEfCore.cs
+++ b/Generator/Templates/TemplateEfCore.cs
@@ -174,12 +174,14 @@ using {{this}};{{#newline}}
     private readonly IConfiguration _configuration;{{#newline}}{{#newline}}
 {{/if}}
 
+{{#if AddParameterlessConstructorToDbContext}}
     public {{DbContextName}}(){{#newline}}
     {{{#newline}}
 {{#if DbContextClassIsPartial}}
         InitializePartial();{{#newline}}
 {{/if}}
     }{{#newline}}{{#newline}}
+{{/if}}
 
     public {{DbContextName}}(DbContextOptions<{{DbContextName}}> options){{#newline}}
         : base(options){{#newline}}


### PR DESCRIPTION
Need to be able to specify removal of the parameterless constructor in efcore to support DB pooling.

With both the parameterless and DbContextOptions constructor you get the following error when you try to use DB pooling

System.InvalidOperationException: The DbContext of type 'xxxx' cannot be pooled because it does not have a single public constructor accepting a single parameter of type DbContextOptions

The EFCore templates now use the AddParameterlessConstructorToDbContext option to specify if it should be included or not