### PR TITLE
fixed typo 'licence' to 'license'

### DIFF
--- a/BuildTT/BuildTT.cs
+++ b/BuildTT/BuildTT.cs
@@ -123,7 +123,7 @@ namespace BuildTT
     Settings.UsePragma                        = false; // If false, suppresses the writing of #pragma
     Settings.AllowNullStrings                 = false; // If true, will allow string? properties and will add '#nullable enable' to the top of each file
     Settings.UseResharper                     = true;  // If true, will add a list of 'ReSharper disable' comments to the top of each file
-    Settings.ShowLicenseInfo                  = false; // If true, will add the licence info comment to the top of each file
+    Settings.ShowLicenseInfo                  = false; // If true, will add the license info comment to the top of each file
     Settings.IncludeConnectionSettingComments = false; // Add comments describing connection settings used to generate file
     Settings.IncludeCodeGeneratedAttribute    = false; // If true, will include the [GeneratedCode] attribute before classes, false to remove it.
     Settings.IncludeColumnsWithDefaults       = true;  // If true, will set properties to the default value from the database.

--- a/EntityFramework Reverse POCO Generator/license.txt
+++ b/EntityFramework Reverse POCO Generator/license.txt
@@ -1,4 +1,4 @@
-﻿LICENCE AND SERVICES AGREEMENT
+﻿license AND SERVICES AGREEMENT
 
 READ CAREFULLY: 
 
@@ -6,30 +6,30 @@ THE LICENSOR LICENSES THE SOFTWARE AND OTHER MATERIALS ONLY ON THE CONDITION THA
 THE LICENSEE (you as the end user) ACCEPTS ALL OF THE TERMS CONTAINED OR REFERENCED 
 WITHIN THIS AGREEMENT.
 
-By selecting "I accept" when registering for a licence at www.ReversePoco.co.uk, you accept and 
+By selecting "I accept" when registering for a license at www.ReversePoco.co.uk, you accept and 
 agree to this Agreement. You may not accept this Agreement on behalf of another person unless you 
 are above the age of 18 and acting on behalf of a minor as their parent or guardian. 
 If you 'the Licensee' do not accept this Agreement DO NOT SELECT "I ACCEPT" AND DO CONTINUE 
 WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
 
-1. Licence
+1. license
 
-    1.1 Licence Grant  
+    1.1 license Grant  
         If you accept and continue to abide by the conditions in this agreement and pay any applicable fees, 
-        REVERSE POCO grants you a non-exclusive, non-transferable and limited licence to use the licensed 
+        REVERSE POCO grants you a non-exclusive, non-transferable and limited license to use the licensed 
         Material in its source code form (not as object code, an executable or a fully compiled software 
         program).
 
     1.2 Upgrades  
-        The Licensee agrees to comply with such terms in accordance with the applicable licence use and 
+        The Licensee agrees to comply with such terms in accordance with the applicable license use and 
         such terms as modified from time to time which are a part of and incorporated by reference into this 
         Agreement.  The Licensee acknowledges that REVERSE POCO may require a further acceptance of 
         such terms as a condition to receiving or accessing upgraded versions.
 
     1.3 Versions
-        Previous versions of the Materials have been produced under and is subject to the Apache Licence 
+        Previous versions of the Materials have been produced under and is subject to the Apache license 
         version 2.0 which can be found at http://www.apache.org/licenses. All portions of the Material 
-        which are subject to the sub-licence, are clearly indicted within the code. 
+        which are subject to the sub-license, are clearly indicted within the code. 
 
 2. License Limitations and Prohibitions
 
@@ -37,14 +37,14 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
        
         2.1.1   Unauthorised Activities 
         The parties acknowledge and agree that, notwithstanding anything contrary to this Agreement 
-        whether expressly stated, implied or otherwise, no licence is granted outside of this Agreement.
+        whether expressly stated, implied or otherwise, no license is granted outside of this Agreement.
         This Agreement expressly excludes any right to:
             (a) use Excluded Materials; 
             (b) access any REVERSE POCO Materials that the Licensee acquired unlawfully 
                 or in violation of this Agreement; 
             (c) Install or access the Licensed Materials beyond the applicable licensed term 
                 whether a fixed term or relationship program period or term or outside the 
-                scope of the applicable Licence type or Permitted Number;
+                scope of the applicable license type or Permitted Number;
             (d) Install the Licensed Materials on any computer other than a computer 
                 owned, leased or controlled by the Licensee, unless otherwise authorized in 
                 writing by REVERSE POCO; 
@@ -67,8 +67,8 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     2.2 Integration and Recognition 
     The Materials are designed to be installed into Microsoft Visual Studio. The Licensee will then use 
     the Materials to generate entity framework mapping code. If the Licensee creates any programs in 
-    this manner for distribution using a non-commercial (Academic / Trial) licence, then the Licensee is 
-    required to make a prominent reference in such program to the use of the licenced Material. 
+    this manner for distribution using a non-commercial (Academic / Trial) license, then the Licensee is 
+    required to make a prominent reference in such program to the use of the licensed Material. 
 
 3. All Rights Reserved
 
@@ -76,12 +76,12 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     REVERSE POCO and its licensors retain title to and ownership of all other rights with respect to the 
     REVERSE POCO Materials and all copies thereof, including but without limitation, any related 
     copyrights, trademarks, trade secrets, patents, and other intellectual property rights.  The Licensee 
-    has only the limited licences granted with respect to the Licensed Materials expressly set forth in this 
+    has only the limited licenses granted with respect to the Licensed Materials expressly set forth in this 
     Agreement. The Licensee has no other rights either implied or otherwise.  
 
     3.2 
     The Licensee acknowledges and agrees that the REVERSE POCO Materials are licensed, not sold, and 
-    that rights to install and access the Licensed Materials are acquired only under the Licence from 
+    that rights to install and access the Licensed Materials are acquired only under the license from 
     REVERSE POCO. 
 
     3.3
@@ -91,7 +91,7 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     trade secrets of REVERSE POCO. The Materials may only be used for the Licensee's own authorised 
     internal use and the Licensee may not distribute, disclose or otherwise provide the Materials to third 
     parties except as integrated into a program developed by the Licensee and with clear recognition of 
-    this Licence pursuant to 2.2 above. 
+    this license pursuant to 2.2 above. 
 
 4. Limited Warranty and Disclaimers 
 
@@ -104,10 +104,10 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     statutory warranty or remedy that cannot be excluded or limited under law, at REVERSE POCO's 
     option to: 
         (i) attempt to correct or work around any errors or defects; or 
-        (ii) refund the licence fees, if any, paid by Licensee and terminate this 
-             Agreement or the licence specific to such Licensed Materials. Such refund is 
+        (ii) refund the license fees, if any, paid by Licensee and terminate this 
+             Agreement or the license specific to such Licensed Materials. Such refund is 
              subject to the return, during the Warranty Period, of the REVERSE POCO 
-             Materials, with a copy of Licensee's Licence Identification. 
+             Materials, with a copy of Licensee's license Identification. 
 
     THE LIMITED WARRANTY SET FORTH IN THIS SECTION GIVES THE LICENSEE SPECIFIC LEGAL RIGHTS.  
     THE LICENSEE MAY HAVE ADDITIONAL LEGAL RIGHTS UNDER LAW WHICH VARY FROM JURISDICTION 
@@ -152,7 +152,7 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
         for the Licensee's professional judgment or independent testing. The Licensed Materials are 
         intended only to assist Licensee with creating Entity Framework mapping code within a software 
         development environment and is not a substitute for Licensee's own knowledge, skills, development 
-        and testing responsibilities within the program or programs Licensee develops using the Licenced 
+        and testing responsibilities within the program or programs Licensee develops using the licensed 
         Materials.
 
         5.1.3
@@ -173,15 +173,15 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
         deliver specific functionality and that the Licensed Materials provided by REVERSE POCO may not 
         achieve the results the Licensee desires within the Licensee's program.
 
-    5.2 Access to Licence Material
+    5.2 Access to license Material
 
         5.2.1
-        The Licence Material can be downloaded through the Microsoft Marketplace as a tool available to 
+        The license Material can be downloaded through the Microsoft Marketplace as a tool available to 
         use within Microsoft Visual Studio. You must then go to www.ReversePoco.co.uk to purchase a 
-        licence to use the Licenced Material. Once the Licence Material has been authorised for use by the 
-        Licensee, a Licence file will be provided via email to an email address provided by the Licensee. In 
-        addition, the Licence file will also be made available for download from the website for the duration 
-        for which it is valid. The licence file will be read and checked each time the Reverse Generator is run.
+        license to use the licensed Material. Once the license Material has been authorised for use by the 
+        Licensee, a license file will be provided via email to an email address provided by the Licensee. In 
+        addition, the license file will also be made available for download from the website for the duration 
+        for which it is valid. The license file will be read and checked each time the Reverse Generator is run.
 
         5.2.2 Disabled Access 
         LICENSEE ACKNOWLEDGES AND AGREES THAT INSTALLATION OF AND ACCESS TO 
@@ -219,29 +219,29 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     (LIMITATIONS OF LIABILITY) AND THAT THE LIABILITY LIMITATIONS IN THIS SECTION 6 (LIMITATIONS 
     OF LIABILITY) ARE AN ESSENTIAL ELEMENT OF THE AGREEMENT BETWEEN THE PARTIES.
 
-7. Licence Types
+7. license Types
 
-    7.1 Individual commercial licence 
-    If a Licensee is granted an individual licence for the material, then the Licensee may only use the 
-    licence key provided to them and not allow access to or permit the use of such access key to any 
-    other individuals. Licensee may install additional copies of the Licence Materials as needed on 
-    multiple computers or servers provided the Licence Material in its stand-alone form is accessed only 
-    by the Licensee, this does not restrict the Licensee from integrating the Licenced Material into its 
+    7.1 Individual commercial license 
+    If a Licensee is granted an individual license for the material, then the Licensee may only use the 
+    license key provided to them and not allow access to or permit the use of such access key to any 
+    other individuals. Licensee may install additional copies of the license Materials as needed on 
+    multiple computers or servers provided the license Material in its stand-alone form is accessed only 
+    by the Licensee, this does not restrict the Licensee from integrating the licensed Material into its 
     own developed programs and distributing those programs in compliance with section 2.
 
-    7.2 Academic / Non-Commercial Licence
-    If a Licensee is granted an Academic / Non-Commercial Licence for the material, then the Licensee 
-    may only use the licence key provided to them and not allow access to or permit the use of such 
-    access key to any other individuals. Any use of the Licence Material must be used for Academic / 
-    Non-Commercial purposes only. No programs developed utilised under this licence type maybe 
+    7.2 Academic / Non-Commercial license
+    If a Licensee is granted an Academic / Non-Commercial license for the material, then the Licensee 
+    may only use the license key provided to them and not allow access to or permit the use of such 
+    access key to any other individuals. Any use of the license Material must be used for Academic / 
+    Non-Commercial purposes only. No programs developed utilised under this license type maybe 
     distributed for any reason other than Academic / Non-Commercial purposes.
 
     7.3 Evaluation, Demonstration or Trial
-    If a Licensee is granted an "evaluation" "demonstration" "trial" licence for the material then the
-    Licensee may install a single, primary copy of the Licence Materials on one computer or server and
-    allow access to the primary copy of the licence material solely by the Licensee. Licensee may install
-    one copy of the Licenced Material on a single computer or server accessible only by the Licensee. The
-    Licenced Material may be used solely for the Licensee's personal use such as evaluation of the
+    If a Licensee is granted an "evaluation" "demonstration" "trial" license for the material then the
+    Licensee may install a single, primary copy of the license Materials on one computer or server and
+    allow access to the primary copy of the license material solely by the Licensee. Licensee may install
+    one copy of the licensed Material on a single computer or server accessible only by the Licensee. The
+    licensed Material may be used solely for the Licensee's personal use such as evaluation of the
     Licensed Material. This licensed type will be for a fixed term based on the determination of REVERSE
     POCO or if no such term as specified, the term is seven (7) days from installation or as otherwise
     authorised in writing by REVERSE POCO.
@@ -249,11 +249,11 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
 8. Term and Termination
 
     8.1 Term, Termination or Suspension
-    Each licence under this Agreement, with respect to each specific set of Licensed Materials covered 
+    Each license under this Agreement, with respect to each specific set of Licensed Materials covered 
     by this Agreement, will become effective as of the latest to occur of:
         (a) this Agreement becoming effective; or 
-        (b) payment by Licensee of the applicable fees, excluding licences (such as 
-            academic / trial licences) where no fees are required; or
+        (b) payment by Licensee of the applicable fees, excluding licenses (such as 
+            academic / trial licenses) where no fees are required; or
         (c) delivery of the specific Licensed Materials.
 
     8.2
@@ -261,11 +261,11 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     Materials if the other party is in breach of this Agreement and fails to cure such breach within ten 
     (10) days after written notice of the breach.
     However, if the Licensee is in breach of sections 1 or 2 of this Agreement, REVERSE POCO may 
-    terminate this Agreement or Licence of the Licensed Materials immediately upon written notice of 
+    terminate this Agreement or license of the Licensed Materials immediately upon written notice of 
     the breach.
 
     8.3
-    In addition, REVERSE POCO may, as an alternative to termination, suspend the Licensee's licence as 
+    In addition, REVERSE POCO may, as an alternative to termination, suspend the Licensee's license as 
     to the Licensed Materials relating to the Licensed Materials, or any other obligations or Licensee 
     rights under this Agreement (or under other terms, if any, relating to Materials associated with the 
     Licensed Materials), if Licensee fails to make a payment to REVERSE POCO or otherwise fails to 
@@ -282,9 +282,9 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     rights or obligations under this Agreement.
     
     8.6
-    Upon termination or expiration of this Agreement, the licences granted hereunder will terminate.  
-    Upon termination or expiration of any licence granted to the Licensee, the Licensee must cease all 
-    use of REVERSE POCO's Materials to which such licence applies and Uninstall all copies of the 
+    Upon termination or expiration of this Agreement, the licenses granted hereunder will terminate.  
+    Upon termination or expiration of any license granted to the Licensee, the Licensee must cease all 
+    use of REVERSE POCO's Materials to which such license applies and Uninstall all copies of the 
     REVERSE POCO's Materials.
     At REVERSE POCO's request, the Licensee agrees to destroy or return to REVERSE POCO.
     REVERSE POCO reserves the right to require the Licensee to show satisfactory proof that all copies of 

--- a/EntityFramework.Reverse.POCO.Generator/Database NorthwindSqlCe40.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database NorthwindSqlCe40.tt
@@ -106,7 +106,7 @@
     Settings.UsePragma                        = false; // If false, suppresses the writing of #pragma
     Settings.AllowNullStrings                 = false; // If true, will allow string? properties and will add '#nullable enable' to the top of each file
     Settings.UseResharper                     = true;  // If true, will add a list of 'ReSharper disable' comments to the top of each file
-    Settings.ShowLicenseInfo                  = false; // If true, will add the licence info comment to the top of each file
+    Settings.ShowLicenseInfo                  = false; // If true, will add the license info comment to the top of each file
     Settings.IncludeConnectionSettingComments = false; // Add comments describing connection settings used to generate file
     Settings.IncludeCodeGeneratedAttribute    = false; // If true, will include the [GeneratedCode] attribute before classes, false to remove it.
     Settings.IncludeColumnsWithDefaults       = true;  // If true, will set properties to the default value from the database.

--- a/EntityFramework.Reverse.POCO.Generator/Database.tt
+++ b/EntityFramework.Reverse.POCO.Generator/Database.tt
@@ -107,7 +107,7 @@
     Settings.UsePragma                        = false; // If false, suppresses the writing of #pragma
     Settings.AllowNullStrings                 = false; // If true, will allow string? properties and will add '#nullable enable' to the top of each file
     Settings.UseResharper                     = true;  // If true, will add a list of 'ReSharper disable' comments to the top of each file
-    Settings.ShowLicenseInfo                  = false; // If true, will add the licence info comment to the top of each file
+    Settings.ShowLicenseInfo                  = false; // If true, will add the license info comment to the top of each file
     Settings.IncludeConnectionSettingComments = false; // Add comments describing connection settings used to generate file
     Settings.IncludeCodeGeneratedAttribute    = false; // If true, will include the [GeneratedCode] attribute before classes, false to remove it.
     Settings.IncludeColumnsWithDefaults       = true;  // If true, will set properties to the default value from the database.

--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
@@ -101,7 +101,7 @@
         public static bool UsePragma                        = false;  // If false, suppresses the writing of #pragma
         public static bool AllowNullStrings                 = false; // If true, will allow string? properties and will add '#nullable enable' to the top of each file
         public static bool UseResharper                     = false; // If true, will add a list of 'ReSharper disable' comments to the top of each file
-        public static bool ShowLicenseInfo                  = false; // If true, will add the licence info comment to the top of each file
+        public static bool ShowLicenseInfo                  = false; // If true, will add the license info comment to the top of each file
         public static bool IncludeConnectionSettingComments = false; // Add comments describing connection settings used to generate file
         public static bool IncludeCodeGeneratedAttribute    = false; // If true, will include the [GeneratedCode] attribute before classes, false to remove it.
         public static bool IncludeColumnsWithDefaults       = true;  // If true, will set properties to the default value from the database.ro
@@ -3861,8 +3861,8 @@
 
 
         private DbProviderFactory _factory;
-        public bool HasAcademicLicence;
-        public bool HasTrialLicence;
+        public bool HasAcademiclicense;
+        public bool HasTriallicense;
         private readonly StringBuilder _preHeaderInfo;
         private readonly string _codeGeneratedAttribute;
         private readonly FileManagementService _fileManagementService;
@@ -3888,12 +3888,12 @@
 
             try
             {
-                var licence = ReadAndValidateLicence();
-                if(licence == null)
+                var license = ReadAndValidatelicense();
+                if(license == null)
                     return;
 
                 providerName = DatabaseProvider.GetProvider(Settings.DatabaseType);
-                BuildPreHeaderInfo(licence);
+                BuildPreHeaderInfo(license);
 
                 _factory = DbProviderFactories.GetFactory(providerName);
                 if (_factory == null)
@@ -3920,8 +3920,8 @@
                     Settings.AdditionalNamespaces.Add("System.ComponentModel.DataAnnotations.Schema");
                 }
 
-                HasAcademicLicence = licence.LicenceType == LicenceType.Academic;
-                HasTrialLicence    = licence.LicenceType == LicenceType.Trial;
+                HasAcademiclicense = license.licenseType == licenseType.Academic;
+                HasTriallicense    = license.licenseType == licenseType.Trial;
                 InitialisationOk = FilterList.ReadDbContextSettings(DatabaseReader, singleDbContextSubNamespace);
                 _fileManagementService.Init(FilterList.GetFilters(), _fileManagerType);
             }
@@ -3947,37 +3947,37 @@
             }
         }
 
-        private Licence ReadAndValidateLicence()
+        private license ReadAndValidatelicense()
         {
             var path = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
             var file = Path.Combine(path, "ReversePOCO.txt");
-            const string obtainAt = "// Please obtain your licence file at www.ReversePOCO.co.uk, and place it in your documents folder shown above.";
+            const string obtainAt = "// Please obtain your license file at www.ReversePOCO.co.uk, and place it in your documents folder shown above.";
 
             if (!File.Exists(file))
             {
-                _fileManagementService.Error(string.Format("// Licence file {0} not found.", file));
+                _fileManagementService.Error(string.Format("// license file {0} not found.", file));
                 _fileManagementService.Error(obtainAt);
-                return TrialLicenceFallback();
+                return TriallicenseFallback();
             }
 
-            var validator = new LicenceValidator();
+            var validator = new licenseValidator();
             if(!validator.Validate(File.ReadAllText(file)))
             {
                 _fileManagementService.Error(validator.Expired
-                    ? string.Format("// Your licence file {0} has expired.", file)
-                    : string.Format("// Your licence file {0} is not valid.", file));
+                    ? string.Format("// Your license file {0} has expired.", file)
+                    : string.Format("// Your license file {0} is not valid.", file));
 
                 _fileManagementService.Error(obtainAt);
-                return TrialLicenceFallback();
+                return TriallicenseFallback();
             }
 
-            return validator.Licence; // Thank you for having a valid licence and supporting this product :-)
+            return validator.license; // Thank you for having a valid license and supporting this product :-)
         }
 
-        private Licence TrialLicenceFallback()
+        private license TriallicenseFallback()
         {
             _fileManagementService.Error("// Defaulting to Trial version.");
-            return new Licence(string.Empty, string.Empty, LicenceType.Trial, "1", DateTime.MaxValue);
+            return new license(string.Empty, string.Empty, licenseType.Trial, "1", DateTime.MaxValue);
         }
 
         public string DatabaseDetails()
@@ -4479,8 +4479,8 @@
                     table.SetPrimaryKeys();
                 }
 
-                if (HasTrialLicence)
-                    filter.Tables.TrimForTrialLicence();
+                if (HasTriallicense)
+                    filter.Tables.TrimForTriallicense();
             }
         }
 
@@ -4612,7 +4612,7 @@
                     {
                         if (!filter.IsExcluded(sp))
                         {
-                            if (HasTrialLicence)
+                            if (HasTriallicense)
                             {
                                 const int n = 1 + 2 + 3 + 4;
                                 if (filter.StoredProcs.Count < n)
@@ -5210,10 +5210,10 @@
                 }
             }
 
-            if (firstInGroup && (HasAcademicLicence || HasTrialLicence))
+            if (firstInGroup && (HasAcademiclicense || HasTriallicense))
             {
                 lines.Add(IndentedStringBuilder(indentNum, "// ****************************************************************************************************"));
-                lines.Add(IndentedStringBuilder(indentNum, "// This is not a commercial licence, therefore only a few tables/views/stored procedures are generated."));
+                lines.Add(IndentedStringBuilder(indentNum, "// This is not a commercial license, therefore only a few tables/views/stored procedures are generated."));
                 lines.Add(IndentedStringBuilder(indentNum, "// ****************************************************************************************************"));
                 lines.Add(null);
             }
@@ -5269,7 +5269,7 @@
             return ex.Message.Replace("\r\n", "\n").Replace("\n", " ");
         }
 
-        private void BuildPreHeaderInfo(Licence licence)
+        private void BuildPreHeaderInfo(license license)
         {
             if (Settings.ShowLicenseInfo)
             {
@@ -5284,12 +5284,12 @@
 
                 _preHeaderInfo.AppendLine("// Created by Simon Hughes (https://about.me/simon.hughes).");
                 _preHeaderInfo.AppendLine("//");
-                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", LicenceConstants.RegisteredTo, licence.RegisteredTo));
-                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", LicenceConstants.Company, licence.Company));
-                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", LicenceConstants.LicenceType, licence.GetLicenceType()));
-                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", LicenceConstants.NumLicences, licence.NumLicences));
-                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", LicenceConstants.ValidUntil,
-                    licence.ValidUntil.ToString(LicenceConstants.ExpiryFormat).ToUpperInvariant()));
+                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", licenseConstants.RegisteredTo, license.RegisteredTo));
+                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", licenseConstants.Company, license.Company));
+                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", licenseConstants.licenseType, license.GetlicenseType()));
+                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", licenseConstants.Numlicenses, license.Numlicenses));
+                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", licenseConstants.ValidUntil,
+                    license.ValidUntil.ToString(licenseConstants.ExpiryFormat).ToUpperInvariant()));
                 _preHeaderInfo.AppendLine("//");
             }
 
@@ -6944,39 +6944,39 @@
         }
     }
 
-    public class Licence
+    public class license
     {
         public string      RegisteredTo { get; private set; }
         public string      Company      { get; private set; }
-        public LicenceType LicenceType  { get; private set; }
-        public string      NumLicences  { get; private set; }
+        public licenseType licenseType  { get; private set; }
+        public string      Numlicenses  { get; private set; }
         public DateTime    ValidUntil   { get; private set; }
 
-        public Licence(string registeredTo, string company, LicenceType licenceType, string numLicences, DateTime validUntil)
+        public license(string registeredTo, string company, licenseType licenseType, string numlicenses, DateTime validUntil)
         {
             RegisteredTo = registeredTo;
             Company      = company;
-            LicenceType  = licenceType;
-            NumLicences  = numLicences;
+            licenseType  = licenseType;
+            Numlicenses  = numlicenses;
             ValidUntil   = validUntil;
         }
 
-        public string GetLicenceType()
+        public string GetlicenseType()
         {
-            return GetLicenceType(LicenceType);
+            return GetlicenseType(licenseType);
         }
 
-        public static string GetLicenceType(LicenceType licenceType)
+        public static string GetlicenseType(licenseType licenseType)
         {
-            switch (licenceType)
+            switch (licenseType)
             {
-                case LicenceType.Academic:
+                case licenseType.Academic:
                     return "Academic license - for non-commercial use only";
 
-                case LicenceType.Commercial:
+                case licenseType.Commercial:
                     return "Commercial";
 
-                case LicenceType.Trial:
+                case licenseType.Trial:
                     return "Trial - for non-commercial trial use only";
 
                 default:
@@ -6984,12 +6984,12 @@
             }
         }
 
-        public static LicenceType ParseLicenceType(string licenceType)
+        public static licenseType ParselicenseType(string licenseType)
         {
-            licenceType = licenceType.Substring(0, 5);
-            foreach (var type in Enum.GetValues(typeof(LicenceType)).Cast<LicenceType>())
+            licenseType = licenseType.Substring(0, 5);
+            foreach (var type in Enum.GetValues(typeof(licenseType)).Cast<licenseType>())
             {
-                if (GetLicenceType(type).Substring(0, 5) == licenceType)
+                if (GetlicenseType(type).Substring(0, 5) == licenseType)
                     return type;
             }
             throw new ArgumentOutOfRangeException();
@@ -7000,61 +7000,61 @@
             return string.Format("{0}|{1}|{2}|{3}|{4}",
                 RegisteredTo.ToUpperInvariant().Trim(),
                 Company     .ToUpperInvariant().Trim(),
-                GetLicenceType(),
-                NumLicences .ToUpperInvariant().Trim(),
-                ValidUntil  .ToString(LicenceConstants.ExpiryFormat, CultureInfo.InvariantCulture).ToUpperInvariant());
+                GetlicenseType(),
+                Numlicenses .ToUpperInvariant().Trim(),
+                ValidUntil  .ToString(licenseConstants.ExpiryFormat, CultureInfo.InvariantCulture).ToUpperInvariant());
         }
     }
-    public static class LicenceConstants
+    public static class licenseConstants
     {
         public static string ExpiryFormat  = "dd MMM yyyy";
         public static string RegisteredTo  = "Registered to: ";
         public static string Company       = "Company      : ";
-        public static string LicenceType   = "Licence Type : ";
-        public static string NumLicences   = "Licences     : ";
+        public static string licenseType   = "license Type : ";
+        public static string Numlicenses   = "licenses     : ";
         public static string ValidUntil    = "Valid until  : ";
         public static string Signature     = "Signature:";
     }
-    public enum LicenceType
+    public enum licenseType
     {
         Academic,
         Commercial,
         Trial
     }
 
-    public class LicenceValidator
+    public class licenseValidator
     {
         private readonly DigitalSignaturePublic _ds;
-        public Licence Licence;
+        public license license;
         public bool Expired;
 
-        public LicenceValidator()
+        public licenseValidator()
         {
             _ds = new DigitalSignaturePublic();
         }
 
-        public bool Validate(string licenceInput)
+        public bool Validate(string licenseInput)
         {
             try
             {
-                var array = licenceInput.Replace("\n", "\r").Replace("\r\r", "\r").Trim().Split('\r');
+                var array = licenseInput.Replace("\n", "\r").Replace("\r\r", "\r").Trim().Split('\r');
 
-                var expiryText = ParseString(array, LicenceConstants.ValidUntil);
-                var parsedExpiry = DateTime.ParseExact(expiryText, LicenceConstants.ExpiryFormat, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal);
+                var expiryText = ParseString(array, licenseConstants.ValidUntil);
+                var parsedExpiry = DateTime.ParseExact(expiryText, licenseConstants.ExpiryFormat, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal);
                 var expiryEndOfDay = new DateTime(parsedExpiry.Year, parsedExpiry.Month, parsedExpiry.Day, 23, 59, 59, DateTimeKind.Local);
                 Expired = expiryEndOfDay < DateTime.Now;
                 if (Expired)
                     return false;
 
-                Licence = new Licence(
-                    ParseString(array, LicenceConstants.RegisteredTo),
-                    ParseString(array, LicenceConstants.Company),
-                    Licence.ParseLicenceType(ParseString(array, LicenceConstants.LicenceType)),
-                    ParseString(array, LicenceConstants.NumLicences),
+                license = new license(
+                    ParseString(array, licenseConstants.RegisteredTo),
+                    ParseString(array, licenseConstants.Company),
+                    license.ParselicenseType(ParseString(array, licenseConstants.licenseType)),
+                    ParseString(array, licenseConstants.Numlicenses),
                     expiryEndOfDay);
 
                 var foundSignature = false;
-                var sigUpperCase = LicenceConstants.Signature;
+                var sigUpperCase = licenseConstants.Signature;
                 var signature = new StringBuilder(1024);
                 foreach (var line in array)
                 {
@@ -7065,7 +7065,7 @@
                         foundSignature = true;
                 }
 
-                return _ds.VerifySignature(Licence.ToString(), Hex.HexToByteArray(signature.ToString().Trim()));
+                return _ds.VerifySignature(license.ToString(), Hex.HexToByteArray(signature.ToString().Trim()));
             }
             catch
             {
@@ -16028,14 +16028,14 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
             }
         }
 
-        public void TrimForTrialLicence()
+        public void TrimForTriallicense()
         {
             // Mapping tables do not count
             const int n = 1 + 2 + 3 + 4;
-            TrimForLicence(n);
+            TrimForlicense(n);
         }
 
-        private void TrimForLicence(int n)
+        private void TrimForlicense(int n)
         {
             if (this.Count(x => !x.IsMapping) <= n)
                 return;

--- a/EntityFramework.Reverse.POCO.Generator/license.txt
+++ b/EntityFramework.Reverse.POCO.Generator/license.txt
@@ -6,30 +6,30 @@ THE LICENSOR LICENSES THE SOFTWARE AND OTHER MATERIALS ONLY ON THE CONDITION THA
 THE LICENSEE (you as the end user) ACCEPTS ALL OF THE TERMS CONTAINED OR REFERENCED 
 WITHIN THIS AGREEMENT.
 
-By selecting "I accept" when registering for a licence at www.ReversePoco.co.uk, you accept and 
+By selecting "I accept" when registering for a license at www.ReversePoco.co.uk, you accept and 
 agree to this Agreement. You may not accept this Agreement on behalf of another person unless you 
 are above the age of 18 and acting on behalf of a minor as their parent or guardian. 
 If you 'the Licensee' do not accept this Agreement DO NOT SELECT "I ACCEPT" AND DO CONTINUE 
 WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
 
-1. Licence
+1. License
 
-    1.1 Licence Grant  
+    1.1 License Grant  
         If you accept and continue to abide by the conditions in this agreement and pay any applicable fees, 
-        REVERSE POCO grants you a non-exclusive, non-transferable and limited licence to use the licensed 
+        REVERSE POCO grants you a non-exclusive, non-transferable and limited license to use the licensed 
         Material in its source code form (not as object code, an executable or a fully compiled software 
         program).
 
     1.2 Upgrades  
-        The Licensee agrees to comply with such terms in accordance with the applicable licence use and 
+        The Licensee agrees to comply with such terms in accordance with the applicable license use and 
         such terms as modified from time to time which are a part of and incorporated by reference into this 
         Agreement.  The Licensee acknowledges that REVERSE POCO may require a further acceptance of 
         such terms as a condition to receiving or accessing upgraded versions.
 
     1.3 Versions
-        Previous versions of the Materials have been produced under and is subject to the Apache Licence 
+        Previous versions of the Materials have been produced under and is subject to the Apache License 
         version 2.0 which can be found at http://www.apache.org/licenses. All portions of the Material 
-        which are subject to the sub-licence, are clearly indicted within the code. 
+        which are subject to the sub-license, are clearly indicted within the code. 
 
 2. License Limitations and Prohibitions
 
@@ -37,14 +37,14 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
        
         2.1.1   Unauthorised Activities 
         The parties acknowledge and agree that, notwithstanding anything contrary to this Agreement 
-        whether expressly stated, implied or otherwise, no licence is granted outside of this Agreement.
+        whether expressly stated, implied or otherwise, no license is granted outside of this Agreement.
         This Agreement expressly excludes any right to:
             (a) use Excluded Materials; 
             (b) access any REVERSE POCO Materials that the Licensee acquired unlawfully 
                 or in violation of this Agreement; 
             (c) Install or access the Licensed Materials beyond the applicable licensed term 
                 whether a fixed term or relationship program period or term or outside the 
-                scope of the applicable Licence type or Permitted Number;
+                scope of the applicable License type or Permitted Number;
             (d) Install the Licensed Materials on any computer other than a computer 
                 owned, leased or controlled by the Licensee, unless otherwise authorized in 
                 writing by REVERSE POCO; 
@@ -67,7 +67,7 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     2.2 Integration and Recognition 
     The Materials are designed to be installed into Microsoft Visual Studio. The Licensee will then use 
     the Materials to generate entity framework mapping code. If the Licensee creates any programs in 
-    this manner for distribution using a non-commercial (Academic / Trial) licence, then the Licensee is 
+    this manner for distribution using a non-commercial (Academic / Trial) license, then the Licensee is 
     required to make a prominent reference in such program to the use of the licenced Material. 
 
 3. All Rights Reserved
@@ -81,7 +81,7 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
 
     3.2 
     The Licensee acknowledges and agrees that the REVERSE POCO Materials are licensed, not sold, and 
-    that rights to install and access the Licensed Materials are acquired only under the Licence from 
+    that rights to install and access the Licensed Materials are acquired only under the License from 
     REVERSE POCO. 
 
     3.3
@@ -91,7 +91,7 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     trade secrets of REVERSE POCO. The Materials may only be used for the Licensee's own authorised 
     internal use and the Licensee may not distribute, disclose or otherwise provide the Materials to third 
     parties except as integrated into a program developed by the Licensee and with clear recognition of 
-    this Licence pursuant to 2.2 above. 
+    this License pursuant to 2.2 above. 
 
 4. Limited Warranty and Disclaimers 
 
@@ -104,10 +104,10 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     statutory warranty or remedy that cannot be excluded or limited under law, at REVERSE POCO's 
     option to: 
         (i) attempt to correct or work around any errors or defects; or 
-        (ii) refund the licence fees, if any, paid by Licensee and terminate this 
-             Agreement or the licence specific to such Licensed Materials. Such refund is 
+        (ii) refund the license fees, if any, paid by Licensee and terminate this 
+             Agreement or the license specific to such Licensed Materials. Such refund is 
              subject to the return, during the Warranty Period, of the REVERSE POCO 
-             Materials, with a copy of Licensee's Licence Identification. 
+             Materials, with a copy of Licensee's License Identification. 
 
     THE LIMITED WARRANTY SET FORTH IN THIS SECTION GIVES THE LICENSEE SPECIFIC LEGAL RIGHTS.  
     THE LICENSEE MAY HAVE ADDITIONAL LEGAL RIGHTS UNDER LAW WHICH VARY FROM JURISDICTION 
@@ -173,15 +173,15 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
         deliver specific functionality and that the Licensed Materials provided by REVERSE POCO may not 
         achieve the results the Licensee desires within the Licensee's program.
 
-    5.2 Access to Licence Material
+    5.2 Access to License Material
 
         5.2.1
-        The Licence Material can be downloaded through the Microsoft Marketplace as a tool available to 
+        The License Material can be downloaded through the Microsoft Marketplace as a tool available to 
         use within Microsoft Visual Studio. You must then go to www.ReversePoco.co.uk to purchase a 
-        licence to use the Licenced Material. Once the Licence Material has been authorised for use by the 
-        Licensee, a Licence file will be provided via email to an email address provided by the Licensee. In 
-        addition, the Licence file will also be made available for download from the website for the duration 
-        for which it is valid. The licence file will be read and checked each time the Reverse Generator is run.
+        license to use the Licenced Material. Once the License Material has been authorised for use by the 
+        Licensee, a License file will be provided via email to an email address provided by the Licensee. In 
+        addition, the License file will also be made available for download from the website for the duration 
+        for which it is valid. The license file will be read and checked each time the Reverse Generator is run.
 
         5.2.2 Disabled Access 
         LICENSEE ACKNOWLEDGES AND AGREES THAT INSTALLATION OF AND ACCESS TO 
@@ -219,27 +219,27 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     (LIMITATIONS OF LIABILITY) AND THAT THE LIABILITY LIMITATIONS IN THIS SECTION 6 (LIMITATIONS 
     OF LIABILITY) ARE AN ESSENTIAL ELEMENT OF THE AGREEMENT BETWEEN THE PARTIES.
 
-7. Licence Types
+7. License Types
 
-    7.1 Individual commercial licence 
-    If a Licensee is granted an individual licence for the material, then the Licensee may only use the 
-    licence key provided to them and not allow access to or permit the use of such access key to any 
-    other individuals. Licensee may install additional copies of the Licence Materials as needed on 
-    multiple computers or servers provided the Licence Material in its stand-alone form is accessed only 
+    7.1 Individual commercial license 
+    If a Licensee is granted an individual license for the material, then the Licensee may only use the 
+    license key provided to them and not allow access to or permit the use of such access key to any 
+    other individuals. Licensee may install additional copies of the License Materials as needed on 
+    multiple computers or servers provided the License Material in its stand-alone form is accessed only 
     by the Licensee, this does not restrict the Licensee from integrating the Licenced Material into its 
     own developed programs and distributing those programs in compliance with section 2.
 
-    7.2 Academic / Non-Commercial Licence
-    If a Licensee is granted an Academic / Non-Commercial Licence for the material, then the Licensee 
-    may only use the licence key provided to them and not allow access to or permit the use of such 
-    access key to any other individuals. Any use of the Licence Material must be used for Academic / 
-    Non-Commercial purposes only. No programs developed utilised under this licence type maybe 
+    7.2 Academic / Non-Commercial License
+    If a Licensee is granted an Academic / Non-Commercial License for the material, then the Licensee 
+    may only use the license key provided to them and not allow access to or permit the use of such 
+    access key to any other individuals. Any use of the License Material must be used for Academic / 
+    Non-Commercial purposes only. No programs developed utilised under this license type maybe 
     distributed for any reason other than Academic / Non-Commercial purposes.
 
     7.3 Evaluation, Demonstration or Trial
-    If a Licensee is granted an "evaluation" "demonstration" "trial" licence for the material then the
-    Licensee may install a single, primary copy of the Licence Materials on one computer or server and
-    allow access to the primary copy of the licence material solely by the Licensee. Licensee may install
+    If a Licensee is granted an "evaluation" "demonstration" "trial" license for the material then the
+    Licensee may install a single, primary copy of the License Materials on one computer or server and
+    allow access to the primary copy of the license material solely by the Licensee. Licensee may install
     one copy of the Licenced Material on a single computer or server accessible only by the Licensee. The
     Licenced Material may be used solely for the Licensee's personal use such as evaluation of the
     Licensed Material. This licensed type will be for a fixed term based on the determination of REVERSE
@@ -249,7 +249,7 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
 8. Term and Termination
 
     8.1 Term, Termination or Suspension
-    Each licence under this Agreement, with respect to each specific set of Licensed Materials covered 
+    Each license under this Agreement, with respect to each specific set of Licensed Materials covered 
     by this Agreement, will become effective as of the latest to occur of:
         (a) this Agreement becoming effective; or 
         (b) payment by Licensee of the applicable fees, excluding licences (such as 
@@ -261,11 +261,11 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     Materials if the other party is in breach of this Agreement and fails to cure such breach within ten 
     (10) days after written notice of the breach.
     However, if the Licensee is in breach of sections 1 or 2 of this Agreement, REVERSE POCO may 
-    terminate this Agreement or Licence of the Licensed Materials immediately upon written notice of 
+    terminate this Agreement or License of the Licensed Materials immediately upon written notice of 
     the breach.
 
     8.3
-    In addition, REVERSE POCO may, as an alternative to termination, suspend the Licensee's licence as 
+    In addition, REVERSE POCO may, as an alternative to termination, suspend the Licensee's license as 
     to the Licensed Materials relating to the Licensed Materials, or any other obligations or Licensee 
     rights under this Agreement (or under other terms, if any, relating to Materials associated with the 
     Licensed Materials), if Licensee fails to make a payment to REVERSE POCO or otherwise fails to 
@@ -283,8 +283,8 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     
     8.6
     Upon termination or expiration of this Agreement, the licences granted hereunder will terminate.  
-    Upon termination or expiration of any licence granted to the Licensee, the Licensee must cease all 
-    use of REVERSE POCO's Materials to which such licence applies and Uninstall all copies of the 
+    Upon termination or expiration of any license granted to the Licensee, the Licensee must cease all 
+    use of REVERSE POCO's Materials to which such license applies and Uninstall all copies of the 
     REVERSE POCO's Materials.
     At REVERSE POCO's request, the Licensee agrees to destroy or return to REVERSE POCO.
     REVERSE POCO reserves the right to require the Licensee to show satisfactory proof that all copies of 

--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -98,7 +98,7 @@
     <Compile Include="LanguageMapping\PostgresToCSharp.cs" />
     <Compile Include="LanguageMapping\LanguageFactories\SqlServerLanguageFactory.cs" />
     <Compile Include="LanguageMapping\SqlServerToJavascript.cs" />
-    <Compile Include="Licensing\LicenceType.cs" />
+    <Compile Include="Licensing\licenseType.cs" />
     <Compile Include="LanguageMapping\SqlServerToCSharp.cs" />
     <Compile Include="LanguageMapping\IDatabaseToPropertyType.cs" />
     <Compile Include="OnConfiguration.cs" />
@@ -147,9 +147,9 @@
     <Compile Include="TemplateModels\InterfaceModel.cs" />
     <Compile Include="Licensing\DigitalSignaturePublic.cs" />
     <Compile Include="Licensing\Hex.cs" />
-    <Compile Include="Licensing\Licence.cs" />
-    <Compile Include="Licensing\LicenceConstants.cs" />
-    <Compile Include="Licensing\LicenceValidator.cs" />
+    <Compile Include="Licensing\license.cs" />
+    <Compile Include="Licensing\licenseConstants.cs" />
+    <Compile Include="Licensing\licenseValidator.cs" />
     <Compile Include="Mustache\ArgumentCollection.cs" />
     <Compile Include="Mustache\CompoundMustacheGenerator.cs" />
     <Compile Include="Mustache\ConditionTagDefinition.cs" />

--- a/Generator/Generators/Generator.cs
+++ b/Generator/Generators/Generator.cs
@@ -39,8 +39,8 @@ namespace Efrpg.Generators
 
 
         private DbProviderFactory _factory;
-        public bool HasAcademicLicence;
-        public bool HasTrialLicence;
+        public bool HasAcademiclicense;
+        public bool HasTriallicense;
         private readonly StringBuilder _preHeaderInfo;
         private readonly string _codeGeneratedAttribute;
         private readonly FileManagementService _fileManagementService;
@@ -66,12 +66,12 @@ namespace Efrpg.Generators
 
             try
             {
-                var licence = ReadAndValidateLicence();
-                if(licence == null)
+                var license = ReadAndValidatelicense();
+                if(license == null)
                     return;
 
                 providerName = DatabaseProvider.GetProvider(Settings.DatabaseType);
-                BuildPreHeaderInfo(licence);
+                BuildPreHeaderInfo(license);
 
                 _factory = DbProviderFactories.GetFactory(providerName);
                 if (_factory == null)
@@ -98,8 +98,8 @@ namespace Efrpg.Generators
                     Settings.AdditionalNamespaces.Add("System.ComponentModel.DataAnnotations.Schema");
                 }
 
-                HasAcademicLicence = licence.LicenceType == LicenceType.Academic;
-                HasTrialLicence    = licence.LicenceType == LicenceType.Trial;
+                HasAcademiclicense = license.licenseType == licenseType.Academic;
+                HasTriallicense    = license.licenseType == licenseType.Trial;
                 InitialisationOk = FilterList.ReadDbContextSettings(DatabaseReader, singleDbContextSubNamespace);
                 _fileManagementService.Init(FilterList.GetFilters(), _fileManagerType);
             }
@@ -125,37 +125,37 @@ namespace Efrpg.Generators
             }
         }
 
-        private Licence ReadAndValidateLicence()
+        private license ReadAndValidatelicense()
         {
             var path = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
             var file = Path.Combine(path, "ReversePOCO.txt");
-            const string obtainAt = "// Please obtain your licence file at www.ReversePOCO.co.uk, and place it in your documents folder shown above.";
+            const string obtainAt = "// Please obtain your license file at www.ReversePOCO.co.uk, and place it in your documents folder shown above.";
 
             if (!File.Exists(file))
             {
-                _fileManagementService.Error(string.Format("// Licence file {0} not found.", file));
+                _fileManagementService.Error(string.Format("// license file {0} not found.", file));
                 _fileManagementService.Error(obtainAt);
-                return TrialLicenceFallback();
+                return TriallicenseFallback();
             }
 
-            var validator = new LicenceValidator();
+            var validator = new licenseValidator();
             if(!validator.Validate(File.ReadAllText(file)))
             {
                 _fileManagementService.Error(validator.Expired
-                    ? string.Format("// Your licence file {0} has expired.", file)
-                    : string.Format("// Your licence file {0} is not valid.", file));
+                    ? string.Format("// Your license file {0} has expired.", file)
+                    : string.Format("// Your license file {0} is not valid.", file));
 
                 _fileManagementService.Error(obtainAt);
-                return TrialLicenceFallback();
+                return TriallicenseFallback();
             }
 
-            return validator.Licence; // Thank you for having a valid licence and supporting this product :-)
+            return validator.license; // Thank you for having a valid license and supporting this product :-)
         }
 
-        private Licence TrialLicenceFallback()
+        private license TriallicenseFallback()
         {
             _fileManagementService.Error("// Defaulting to Trial version.");
-            return new Licence(string.Empty, string.Empty, LicenceType.Trial, "1", DateTime.MaxValue);
+            return new license(string.Empty, string.Empty, licenseType.Trial, "1", DateTime.MaxValue);
         }
 
         public string DatabaseDetails()
@@ -657,8 +657,8 @@ namespace Efrpg.Generators
                     table.SetPrimaryKeys();
                 }
 
-                if (HasTrialLicence)
-                    filter.Tables.TrimForTrialLicence();
+                if (HasTriallicense)
+                    filter.Tables.TrimForTriallicense();
             }
         }
 
@@ -790,7 +790,7 @@ namespace Efrpg.Generators
                     {
                         if (!filter.IsExcluded(sp))
                         {
-                            if (HasTrialLicence)
+                            if (HasTriallicense)
                             {
                                 const int n = 1 + 2 + 3 + 4;
                                 if (filter.StoredProcs.Count < n)
@@ -1388,10 +1388,10 @@ namespace Efrpg.Generators
                 }
             }
 
-            if (firstInGroup && (HasAcademicLicence || HasTrialLicence))
+            if (firstInGroup && (HasAcademiclicense || HasTriallicense))
             {
                 lines.Add(IndentedStringBuilder(indentNum, "// ****************************************************************************************************"));
-                lines.Add(IndentedStringBuilder(indentNum, "// This is not a commercial licence, therefore only a few tables/views/stored procedures are generated."));
+                lines.Add(IndentedStringBuilder(indentNum, "// This is not a commercial license, therefore only a few tables/views/stored procedures are generated."));
                 lines.Add(IndentedStringBuilder(indentNum, "// ****************************************************************************************************"));
                 lines.Add(null);
             }
@@ -1447,7 +1447,7 @@ namespace Efrpg.Generators
             return ex.Message.Replace("\r\n", "\n").Replace("\n", " ");
         }
 
-        private void BuildPreHeaderInfo(Licence licence)
+        private void BuildPreHeaderInfo(license license)
         {
             if (Settings.ShowLicenseInfo)
             {
@@ -1462,12 +1462,12 @@ namespace Efrpg.Generators
 
                 _preHeaderInfo.AppendLine("// Created by Simon Hughes (https://about.me/simon.hughes).");
                 _preHeaderInfo.AppendLine("//");
-                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", LicenceConstants.RegisteredTo, licence.RegisteredTo));
-                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", LicenceConstants.Company, licence.Company));
-                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", LicenceConstants.LicenceType, licence.GetLicenceType()));
-                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", LicenceConstants.NumLicences, licence.NumLicences));
-                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", LicenceConstants.ValidUntil,
-                    licence.ValidUntil.ToString(LicenceConstants.ExpiryFormat).ToUpperInvariant()));
+                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", licenseConstants.RegisteredTo, license.RegisteredTo));
+                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", licenseConstants.Company, license.Company));
+                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", licenseConstants.licenseType, license.GetlicenseType()));
+                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", licenseConstants.Numlicenses, license.Numlicenses));
+                _preHeaderInfo.AppendLine(string.Format("// {0}{1}", licenseConstants.ValidUntil,
+                    license.ValidUntil.ToString(licenseConstants.ExpiryFormat).ToUpperInvariant()));
                 _preHeaderInfo.AppendLine("//");
             }
 

--- a/Generator/Licensing/Licence.cs
+++ b/Generator/Licensing/Licence.cs
@@ -4,39 +4,39 @@ using System.Linq;
 
 namespace Efrpg.Licensing
 {
-    public class Licence
+    public class license
     {
         public string      RegisteredTo { get; private set; }
         public string      Company      { get; private set; }
-        public LicenceType LicenceType  { get; private set; }
-        public string      NumLicences  { get; private set; }
+        public licenseType licenseType  { get; private set; }
+        public string      Numlicenses  { get; private set; }
         public DateTime    ValidUntil   { get; private set; }
 
-        public Licence(string registeredTo, string company, LicenceType licenceType, string numLicences, DateTime validUntil)
+        public license(string registeredTo, string company, licenseType licenseType, string numlicenses, DateTime validUntil)
         {
             RegisteredTo = registeredTo;
             Company      = company;
-            LicenceType  = licenceType;
-            NumLicences  = numLicences;
+            licenseType  = licenseType;
+            Numlicenses  = numlicenses;
             ValidUntil   = validUntil;
         }
 
-        public string GetLicenceType()
+        public string GetlicenseType()
         {
-            return GetLicenceType(LicenceType);
+            return GetlicenseType(licenseType);
         }
 
-        public static string GetLicenceType(LicenceType licenceType)
+        public static string GetlicenseType(licenseType licenseType)
         {
-            switch (licenceType)
+            switch (licenseType)
             {
-                case LicenceType.Academic:
+                case licenseType.Academic:
                     return "Academic license - for non-commercial use only";
 
-                case LicenceType.Commercial:
+                case licenseType.Commercial:
                     return "Commercial";
 
-                case LicenceType.Trial:
+                case licenseType.Trial:
                     return "Trial - for non-commercial trial use only";
 
                 default:
@@ -44,12 +44,12 @@ namespace Efrpg.Licensing
             }
         }
 
-        public static LicenceType ParseLicenceType(string licenceType)
+        public static licenseType ParselicenseType(string licenseType)
         {
-            licenceType = licenceType.Substring(0, 5);
-            foreach (var type in Enum.GetValues(typeof(LicenceType)).Cast<LicenceType>())
+            licenseType = licenseType.Substring(0, 5);
+            foreach (var type in Enum.GetValues(typeof(licenseType)).Cast<licenseType>())
             {
-                if (GetLicenceType(type).Substring(0, 5) == licenceType)
+                if (GetlicenseType(type).Substring(0, 5) == licenseType)
                     return type;
             }
             throw new ArgumentOutOfRangeException();
@@ -60,9 +60,9 @@ namespace Efrpg.Licensing
             return string.Format("{0}|{1}|{2}|{3}|{4}",
                 RegisteredTo.ToUpperInvariant().Trim(),
                 Company     .ToUpperInvariant().Trim(),
-                GetLicenceType(),
-                NumLicences .ToUpperInvariant().Trim(),
-                ValidUntil  .ToString(LicenceConstants.ExpiryFormat, CultureInfo.InvariantCulture).ToUpperInvariant());
+                GetlicenseType(),
+                Numlicenses .ToUpperInvariant().Trim(),
+                ValidUntil  .ToString(licenseConstants.ExpiryFormat, CultureInfo.InvariantCulture).ToUpperInvariant());
         }
     }
 }

--- a/Generator/Licensing/LicenceConstants.cs
+++ b/Generator/Licensing/LicenceConstants.cs
@@ -1,12 +1,12 @@
 ﻿namespace Efrpg.Licensing
 {
-    public static class LicenceConstants
+    public static class licenseConstants
     {
         public static string ExpiryFormat  = "dd MMM yyyy";
         public static string RegisteredTo  = "Registered to: ";
         public static string Company       = "Company      : ";
-        public static string LicenceType   = "Licence Type : ";
-        public static string NumLicences   = "Licences     : ";
+        public static string licenseType   = "license Type : ";
+        public static string Numlicenses   = "licenses     : ";
         public static string ValidUntil    = "Valid until  : ";
         public static string Signature     = "Signature:";
     }

--- a/Generator/Licensing/LicenceType.cs
+++ b/Generator/Licensing/LicenceType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Efrpg.Licensing
 {
-    public enum LicenceType
+    public enum licenseType
     {
         Academic,
         Commercial,

--- a/Generator/Licensing/LicenceValidator.cs
+++ b/Generator/Licensing/LicenceValidator.cs
@@ -4,39 +4,39 @@ using System.Text;
 
 namespace Efrpg.Licensing
 {
-    public class LicenceValidator
+    public class licenseValidator
     {
         private readonly DigitalSignaturePublic _ds;
-        public Licence Licence;
+        public license license;
         public bool Expired;
 
-        public LicenceValidator()
+        public licenseValidator()
         {
             _ds = new DigitalSignaturePublic();
         }
 
-        public bool Validate(string licenceInput)
+        public bool Validate(string licenseInput)
         {
             try
             {
-                var array = licenceInput.Replace("\n", "\r").Replace("\r\r", "\r").Trim().Split('\r');
+                var array = licenseInput.Replace("\n", "\r").Replace("\r\r", "\r").Trim().Split('\r');
 
-                var expiryText = ParseString(array, LicenceConstants.ValidUntil);
-                var parsedExpiry = DateTime.ParseExact(expiryText, LicenceConstants.ExpiryFormat, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal);
+                var expiryText = ParseString(array, licenseConstants.ValidUntil);
+                var parsedExpiry = DateTime.ParseExact(expiryText, licenseConstants.ExpiryFormat, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal);
                 var expiryEndOfDay = new DateTime(parsedExpiry.Year, parsedExpiry.Month, parsedExpiry.Day, 23, 59, 59, DateTimeKind.Local);
                 Expired = expiryEndOfDay < DateTime.Now;
                 if (Expired)
                     return false;
 
-                Licence = new Licence(
-                    ParseString(array, LicenceConstants.RegisteredTo),
-                    ParseString(array, LicenceConstants.Company),
-                    Licence.ParseLicenceType(ParseString(array, LicenceConstants.LicenceType)),
-                    ParseString(array, LicenceConstants.NumLicences),
+                license = new license(
+                    ParseString(array, licenseConstants.RegisteredTo),
+                    ParseString(array, licenseConstants.Company),
+                    license.ParselicenseType(ParseString(array, licenseConstants.licenseType)),
+                    ParseString(array, licenseConstants.Numlicenses),
                     expiryEndOfDay);
 
                 var foundSignature = false;
-                var sigUpperCase = LicenceConstants.Signature;
+                var sigUpperCase = licenseConstants.Signature;
                 var signature = new StringBuilder(1024);
                 foreach (var line in array)
                 {
@@ -47,7 +47,7 @@ namespace Efrpg.Licensing
                         foundSignature = true;
                 }
 
-                return _ds.VerifySignature(Licence.ToString(), Hex.HexToByteArray(signature.ToString().Trim()));
+                return _ds.VerifySignature(license.ToString(), Hex.HexToByteArray(signature.ToString().Trim()));
             }
             catch
             {

--- a/Generator/Settings.cs
+++ b/Generator/Settings.cs
@@ -75,7 +75,7 @@ namespace Efrpg
         public static bool UsePragma                        = false;  // If false, suppresses the writing of #pragma
         public static bool AllowNullStrings                 = false; // If true, will allow string? properties and will add '#nullable enable' to the top of each file
         public static bool UseResharper                     = false; // If true, will add a list of 'ReSharper disable' comments to the top of each file
-        public static bool ShowLicenseInfo                  = false; // If true, will add the licence info comment to the top of each file
+        public static bool ShowLicenseInfo                  = false; // If true, will add the license info comment to the top of each file
         public static bool IncludeConnectionSettingComments = false; // Add comments describing connection settings used to generate file
         public static bool IncludeCodeGeneratedAttribute    = false; // If true, will include the [GeneratedCode] attribute before classes, false to remove it.
         public static bool IncludeColumnsWithDefaults       = true;  // If true, will set properties to the default value from the database.ro

--- a/Generator/Tables.cs
+++ b/Generator/Tables.cs
@@ -29,14 +29,14 @@ namespace Efrpg
             }
         }
 
-        public void TrimForTrialLicence()
+        public void TrimForTriallicense()
         {
             // Mapping tables do not count
             const int n = 1 + 2 + 3 + 4;
-            TrimForLicence(n);
+            TrimForlicense(n);
         }
 
-        private void TrimForLicence(int n)
+        private void TrimForlicense(int n)
         {
             if (this.Count(x => !x.IsMapping) <= n)
                 return;

--- a/ItemTemplate/license.txt
+++ b/ItemTemplate/license.txt
@@ -1,4 +1,4 @@
-LICENCE AND SERVICES AGREEMENT
+license AND SERVICES AGREEMENT
 
 READ CAREFULLY: 
 
@@ -6,30 +6,30 @@ THE LICENSOR LICENSES THE SOFTWARE AND OTHER MATERIALS ONLY ON THE CONDITION THA
 THE LICENSEE (you as the end user) ACCEPTS ALL OF THE TERMS CONTAINED OR REFERENCED 
 WITHIN THIS AGREEMENT.
 
-By selecting "I accept" when registering for a licence at www.ReversePoco.co.uk, you accept and 
+By selecting "I accept" when registering for a license at www.ReversePoco.co.uk, you accept and 
 agree to this Agreement. You may not accept this Agreement on behalf of another person unless you 
 are above the age of 18 and acting on behalf of a minor as their parent or guardian. 
 If you 'the Licensee' do not accept this Agreement DO NOT SELECT "I ACCEPT" AND DO CONTINUE 
 WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
 
-1. Licence
+1. license
 
-    1.1 Licence Grant  
+    1.1 license Grant  
         If you accept and continue to abide by the conditions in this agreement and pay any applicable fees, 
-        REVERSE POCO grants you a non-exclusive, non-transferable and limited licence to use the licensed 
+        REVERSE POCO grants you a non-exclusive, non-transferable and limited license to use the licensed 
         Material in its source code form (not as object code, an executable or a fully compiled software 
         program).
 
     1.2 Upgrades  
-        The Licensee agrees to comply with such terms in accordance with the applicable licence use and 
+        The Licensee agrees to comply with such terms in accordance with the applicable license use and 
         such terms as modified from time to time which are a part of and incorporated by reference into this 
         Agreement.  The Licensee acknowledges that REVERSE POCO may require a further acceptance of 
         such terms as a condition to receiving or accessing upgraded versions.
 
     1.3 Versions
-        Previous versions of the Materials have been produced under and is subject to the Apache Licence 
+        Previous versions of the Materials have been produced under and is subject to the Apache license 
         version 2.0 which can be found at http://www.apache.org/licenses. All portions of the Material 
-        which are subject to the sub-licence, are clearly indicted within the code. 
+        which are subject to the sub-license, are clearly indicted within the code. 
 
 2. License Limitations and Prohibitions
 
@@ -37,14 +37,14 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
        
         2.1.1   Unauthorised Activities 
         The parties acknowledge and agree that, notwithstanding anything contrary to this Agreement 
-        whether expressly stated, implied or otherwise, no licence is granted outside of this Agreement.
+        whether expressly stated, implied or otherwise, no license is granted outside of this Agreement.
         This Agreement expressly excludes any right to:
             (a) use Excluded Materials; 
             (b) access any REVERSE POCO Materials that the Licensee acquired unlawfully 
                 or in violation of this Agreement; 
             (c) Install or access the Licensed Materials beyond the applicable licensed term 
                 whether a fixed term or relationship program period or term or outside the 
-                scope of the applicable Licence type or Permitted Number;
+                scope of the applicable license type or Permitted Number;
             (d) Install the Licensed Materials on any computer other than a computer 
                 owned, leased or controlled by the Licensee, unless otherwise authorized in 
                 writing by REVERSE POCO; 
@@ -67,8 +67,8 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     2.2 Integration and Recognition 
     The Materials are designed to be installed into Microsoft Visual Studio. The Licensee will then use 
     the Materials to generate entity framework mapping code. If the Licensee creates any programs in 
-    this manner for distribution using a non-commercial (Academic / Trial) licence, then the Licensee is 
-    required to make a prominent reference in such program to the use of the licenced Material. 
+    this manner for distribution using a non-commercial (Academic / Trial) license, then the Licensee is 
+    required to make a prominent reference in such program to the use of the licensed Material. 
 
 3. All Rights Reserved
 
@@ -76,12 +76,12 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     REVERSE POCO and its licensors retain title to and ownership of all other rights with respect to the 
     REVERSE POCO Materials and all copies thereof, including but without limitation, any related 
     copyrights, trademarks, trade secrets, patents, and other intellectual property rights.  The Licensee 
-    has only the limited licences granted with respect to the Licensed Materials expressly set forth in this 
+    has only the limited licenses granted with respect to the Licensed Materials expressly set forth in this 
     Agreement. The Licensee has no other rights either implied or otherwise.  
 
     3.2 
     The Licensee acknowledges and agrees that the REVERSE POCO Materials are licensed, not sold, and 
-    that rights to install and access the Licensed Materials are acquired only under the Licence from 
+    that rights to install and access the Licensed Materials are acquired only under the license from 
     REVERSE POCO. 
 
     3.3
@@ -91,7 +91,7 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     trade secrets of REVERSE POCO. The Materials may only be used for the Licensee's own authorised 
     internal use and the Licensee may not distribute, disclose or otherwise provide the Materials to third 
     parties except as integrated into a program developed by the Licensee and with clear recognition of 
-    this Licence pursuant to 2.2 above. 
+    this license pursuant to 2.2 above. 
 
 4. Limited Warranty and Disclaimers 
 
@@ -104,10 +104,10 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     statutory warranty or remedy that cannot be excluded or limited under law, at REVERSE POCO's 
     option to: 
         (i) attempt to correct or work around any errors or defects; or 
-        (ii) refund the licence fees, if any, paid by Licensee and terminate this 
-             Agreement or the licence specific to such Licensed Materials. Such refund is 
+        (ii) refund the license fees, if any, paid by Licensee and terminate this 
+             Agreement or the license specific to such Licensed Materials. Such refund is 
              subject to the return, during the Warranty Period, of the REVERSE POCO 
-             Materials, with a copy of Licensee's Licence Identification. 
+             Materials, with a copy of Licensee's license Identification. 
 
     THE LIMITED WARRANTY SET FORTH IN THIS SECTION GIVES THE LICENSEE SPECIFIC LEGAL RIGHTS.  
     THE LICENSEE MAY HAVE ADDITIONAL LEGAL RIGHTS UNDER LAW WHICH VARY FROM JURISDICTION 
@@ -152,7 +152,7 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
         for the Licensee's professional judgment or independent testing. The Licensed Materials are 
         intended only to assist Licensee with creating Entity Framework mapping code within a software 
         development environment and is not a substitute for Licensee's own knowledge, skills, development 
-        and testing responsibilities within the program or programs Licensee develops using the Licenced 
+        and testing responsibilities within the program or programs Licensee develops using the licensed 
         Materials.
 
         5.1.3
@@ -173,15 +173,15 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
         deliver specific functionality and that the Licensed Materials provided by REVERSE POCO may not 
         achieve the results the Licensee desires within the Licensee's program.
 
-    5.2 Access to Licence Material
+    5.2 Access to license Material
 
         5.2.1
-        The Licence Material can be downloaded through the Microsoft Marketplace as a tool available to 
+        The license Material can be downloaded through the Microsoft Marketplace as a tool available to 
         use within Microsoft Visual Studio. You must then go to www.ReversePoco.co.uk to purchase a 
-        licence to use the Licenced Material. Once the Licence Material has been authorised for use by the 
-        Licensee, a Licence file will be provided via email to an email address provided by the Licensee. In 
-        addition, the Licence file will also be made available for download from the website for the duration 
-        for which it is valid. The licence file will be read and checked each time the Reverse Generator is run.
+        license to use the licensed Material. Once the license Material has been authorised for use by the 
+        Licensee, a license file will be provided via email to an email address provided by the Licensee. In 
+        addition, the license file will also be made available for download from the website for the duration 
+        for which it is valid. The license file will be read and checked each time the Reverse Generator is run.
 
         5.2.2 Disabled Access 
         LICENSEE ACKNOWLEDGES AND AGREES THAT INSTALLATION OF AND ACCESS TO 
@@ -219,29 +219,29 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     (LIMITATIONS OF LIABILITY) AND THAT THE LIABILITY LIMITATIONS IN THIS SECTION 6 (LIMITATIONS 
     OF LIABILITY) ARE AN ESSENTIAL ELEMENT OF THE AGREEMENT BETWEEN THE PARTIES.
 
-7. Licence Types
+7. license Types
 
-    7.1 Individual commercial licence 
-    If a Licensee is granted an individual licence for the material, then the Licensee may only use the 
-    licence key provided to them and not allow access to or permit the use of such access key to any 
-    other individuals. Licensee may install additional copies of the Licence Materials as needed on 
-    multiple computers or servers provided the Licence Material in its stand-alone form is accessed only 
-    by the Licensee, this does not restrict the Licensee from integrating the Licenced Material into its 
+    7.1 Individual commercial license 
+    If a Licensee is granted an individual license for the material, then the Licensee may only use the 
+    license key provided to them and not allow access to or permit the use of such access key to any 
+    other individuals. Licensee may install additional copies of the license Materials as needed on 
+    multiple computers or servers provided the license Material in its stand-alone form is accessed only 
+    by the Licensee, this does not restrict the Licensee from integrating the licensed Material into its 
     own developed programs and distributing those programs in compliance with section 2.
 
-    7.2 Academic / Non-Commercial Licence
-    If a Licensee is granted an Academic / Non-Commercial Licence for the material, then the Licensee 
-    may only use the licence key provided to them and not allow access to or permit the use of such 
-    access key to any other individuals. Any use of the Licence Material must be used for Academic / 
-    Non-Commercial purposes only. No programs developed utilised under this licence type maybe 
+    7.2 Academic / Non-Commercial license
+    If a Licensee is granted an Academic / Non-Commercial license for the material, then the Licensee 
+    may only use the license key provided to them and not allow access to or permit the use of such 
+    access key to any other individuals. Any use of the license Material must be used for Academic / 
+    Non-Commercial purposes only. No programs developed utilised under this license type maybe 
     distributed for any reason other than Academic / Non-Commercial purposes.
 
     7.3 Evaluation, Demonstration or Trial
-    If a Licensee is granted an "evaluation" "demonstration" "trial" licence for the material then the
-    Licensee may install a single, primary copy of the Licence Materials on one computer or server and
-    allow access to the primary copy of the licence material solely by the Licensee. Licensee may install
-    one copy of the Licenced Material on a single computer or server accessible only by the Licensee. The
-    Licenced Material may be used solely for the Licensee's personal use such as evaluation of the
+    If a Licensee is granted an "evaluation" "demonstration" "trial" license for the material then the
+    Licensee may install a single, primary copy of the license Materials on one computer or server and
+    allow access to the primary copy of the license material solely by the Licensee. Licensee may install
+    one copy of the licensed Material on a single computer or server accessible only by the Licensee. The
+    licensed Material may be used solely for the Licensee's personal use such as evaluation of the
     Licensed Material. This licensed type will be for a fixed term based on the determination of REVERSE
     POCO or if no such term as specified, the term is seven (7) days from installation or as otherwise
     authorised in writing by REVERSE POCO.
@@ -249,11 +249,11 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
 8. Term and Termination
 
     8.1 Term, Termination or Suspension
-    Each licence under this Agreement, with respect to each specific set of Licensed Materials covered 
+    Each license under this Agreement, with respect to each specific set of Licensed Materials covered 
     by this Agreement, will become effective as of the latest to occur of:
         (a) this Agreement becoming effective; or 
-        (b) payment by Licensee of the applicable fees, excluding licences (such as 
-            academic / trial licences) where no fees are required; or
+        (b) payment by Licensee of the applicable fees, excluding licenses (such as 
+            academic / trial licenses) where no fees are required; or
         (c) delivery of the specific Licensed Materials.
 
     8.2
@@ -261,11 +261,11 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     Materials if the other party is in breach of this Agreement and fails to cure such breach within ten 
     (10) days after written notice of the breach.
     However, if the Licensee is in breach of sections 1 or 2 of this Agreement, REVERSE POCO may 
-    terminate this Agreement or Licence of the Licensed Materials immediately upon written notice of 
+    terminate this Agreement or license of the Licensed Materials immediately upon written notice of 
     the breach.
 
     8.3
-    In addition, REVERSE POCO may, as an alternative to termination, suspend the Licensee's licence as 
+    In addition, REVERSE POCO may, as an alternative to termination, suspend the Licensee's license as 
     to the Licensed Materials relating to the Licensed Materials, or any other obligations or Licensee 
     rights under this Agreement (or under other terms, if any, relating to Materials associated with the 
     Licensed Materials), if Licensee fails to make a payment to REVERSE POCO or otherwise fails to 
@@ -282,9 +282,9 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     rights or obligations under this Agreement.
     
     8.6
-    Upon termination or expiration of this Agreement, the licences granted hereunder will terminate.  
-    Upon termination or expiration of any licence granted to the Licensee, the Licensee must cease all 
-    use of REVERSE POCO's Materials to which such licence applies and Uninstall all copies of the 
+    Upon termination or expiration of this Agreement, the licenses granted hereunder will terminate.  
+    Upon termination or expiration of any license granted to the Licensee, the Licensee must cease all 
+    use of REVERSE POCO's Materials to which such license applies and Uninstall all copies of the 
     REVERSE POCO's Materials.
     At REVERSE POCO's request, the Licensee agrees to destroy or return to REVERSE POCO.
     REVERSE POCO reserves the right to require the Licensee to show satisfactory proof that all copies of 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-LICENCE AND SERVICES AGREEMENT
+license AND SERVICES AGREEMENT
 
 READ CAREFULLY: 
 
@@ -6,30 +6,30 @@ THE LICENSOR LICENSES THE SOFTWARE AND OTHER MATERIALS ONLY ON THE CONDITION THA
 THE LICENSEE (you as the end user) ACCEPTS ALL OF THE TERMS CONTAINED OR REFERENCED 
 WITHIN THIS AGREEMENT.
 
-By selecting "I accept" when registering for a licence at www.ReversePoco.co.uk, you accept and 
+By selecting "I accept" when registering for a license at www.ReversePoco.co.uk, you accept and 
 agree to this Agreement. You may not accept this Agreement on behalf of another person unless you 
 are above the age of 18 and acting on behalf of a minor as their parent or guardian. 
 If you 'the Licensee' do not accept this Agreement DO NOT SELECT "I ACCEPT" AND DO CONTINUE 
 WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
 
-1. Licence
+1. license
 
-    1.1 Licence Grant  
+    1.1 license Grant  
         If you accept and continue to abide by the conditions in this agreement and pay any applicable fees, 
-        REVERSE POCO grants you a non-exclusive, non-transferable and limited licence to use the licensed 
+        REVERSE POCO grants you a non-exclusive, non-transferable and limited license to use the licensed 
         Material in its source code form (not as object code, an executable or a fully compiled software 
         program).
 
     1.2 Upgrades  
-        The Licensee agrees to comply with such terms in accordance with the applicable licence use and 
+        The Licensee agrees to comply with such terms in accordance with the applicable license use and 
         such terms as modified from time to time which are a part of and incorporated by reference into this 
         Agreement.  The Licensee acknowledges that REVERSE POCO may require a further acceptance of 
         such terms as a condition to receiving or accessing upgraded versions.
 
     1.3 Versions
-        Previous versions of the Materials have been produced under and is subject to the Apache Licence 
+        Previous versions of the Materials have been produced under and is subject to the Apache license 
         version 2.0 which can be found at http://www.apache.org/licenses. All portions of the Material 
-        which are subject to the sub-licence, are clearly indicted within the code. 
+        which are subject to the sub-license, are clearly indicted within the code. 
 
 2. License Limitations and Prohibitions
 
@@ -37,14 +37,14 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
        
         2.1.1   Unauthorised Activities 
         The parties acknowledge and agree that, notwithstanding anything contrary to this Agreement 
-        whether expressly stated, implied or otherwise, no licence is granted outside of this Agreement.
+        whether expressly stated, implied or otherwise, no license is granted outside of this Agreement.
         This Agreement expressly excludes any right to:
             (a) use Excluded Materials; 
             (b) access any REVERSE POCO Materials that the Licensee acquired unlawfully 
                 or in violation of this Agreement; 
             (c) Install or access the Licensed Materials beyond the applicable licensed term 
                 whether a fixed term or relationship program period or term or outside the 
-                scope of the applicable Licence type or Permitted Number;
+                scope of the applicable license type or Permitted Number;
             (d) Install the Licensed Materials on any computer other than a computer 
                 owned, leased or controlled by the Licensee, unless otherwise authorized in 
                 writing by REVERSE POCO; 
@@ -67,8 +67,8 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     2.2 Integration and Recognition 
     The Materials are designed to be installed into Microsoft Visual Studio. The Licensee will then use 
     the Materials to generate entity framework mapping code. If the Licensee creates any programs in 
-    this manner for distribution using a non-commercial (Academic / Trial) licence, then the Licensee is 
-    required to make a prominent reference in such program to the use of the licenced Material. 
+    this manner for distribution using a non-commercial (Academic / Trial) license, then the Licensee is 
+    required to make a prominent reference in such program to the use of the licensed Material. 
 
 3. All Rights Reserved
 
@@ -76,12 +76,12 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     REVERSE POCO and its licensors retain title to and ownership of all other rights with respect to the 
     REVERSE POCO Materials and all copies thereof, including but without limitation, any related 
     copyrights, trademarks, trade secrets, patents, and other intellectual property rights.  The Licensee 
-    has only the limited licences granted with respect to the Licensed Materials expressly set forth in this 
+    has only the limited licenses granted with respect to the Licensed Materials expressly set forth in this 
     Agreement. The Licensee has no other rights either implied or otherwise.  
 
     3.2 
     The Licensee acknowledges and agrees that the REVERSE POCO Materials are licensed, not sold, and 
-    that rights to install and access the Licensed Materials are acquired only under the Licence from 
+    that rights to install and access the Licensed Materials are acquired only under the license from 
     REVERSE POCO. 
 
     3.3
@@ -91,7 +91,7 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     trade secrets of REVERSE POCO. The Materials may only be used for the Licensee's own authorised 
     internal use and the Licensee may not distribute, disclose or otherwise provide the Materials to third 
     parties except as integrated into a program developed by the Licensee and with clear recognition of 
-    this Licence pursuant to 2.2 above. 
+    this license pursuant to 2.2 above. 
 
 4. Limited Warranty and Disclaimers 
 
@@ -104,10 +104,10 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     statutory warranty or remedy that cannot be excluded or limited under law, at REVERSE POCO's 
     option to: 
         (i) attempt to correct or work around any errors or defects; or 
-        (ii) refund the licence fees, if any, paid by Licensee and terminate this 
-             Agreement or the licence specific to such Licensed Materials. Such refund is 
+        (ii) refund the license fees, if any, paid by Licensee and terminate this 
+             Agreement or the license specific to such Licensed Materials. Such refund is 
              subject to the return, during the Warranty Period, of the REVERSE POCO 
-             Materials, with a copy of Licensee's Licence Identification. 
+             Materials, with a copy of Licensee's license Identification. 
 
     THE LIMITED WARRANTY SET FORTH IN THIS SECTION GIVES THE LICENSEE SPECIFIC LEGAL RIGHTS.  
     THE LICENSEE MAY HAVE ADDITIONAL LEGAL RIGHTS UNDER LAW WHICH VARY FROM JURISDICTION 
@@ -152,7 +152,7 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
         for the Licensee's professional judgment or independent testing. The Licensed Materials are 
         intended only to assist Licensee with creating Entity Framework mapping code within a software 
         development environment and is not a substitute for Licensee's own knowledge, skills, development 
-        and testing responsibilities within the program or programs Licensee develops using the Licenced 
+        and testing responsibilities within the program or programs Licensee develops using the licensed 
         Materials.
 
         5.1.3
@@ -173,15 +173,15 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
         deliver specific functionality and that the Licensed Materials provided by REVERSE POCO may not 
         achieve the results the Licensee desires within the Licensee's program.
 
-    5.2 Access to Licence Material
+    5.2 Access to license Material
 
         5.2.1
-        The Licence Material can be downloaded through the Microsoft Marketplace as a tool available to 
+        The license Material can be downloaded through the Microsoft Marketplace as a tool available to 
         use within Microsoft Visual Studio. You must then go to www.ReversePoco.co.uk to purchase a 
-        licence to use the Licenced Material. Once the Licence Material has been authorised for use by the 
-        Licensee, a Licence file will be provided via email to an email address provided by the Licensee. In 
-        addition, the Licence file will also be made available for download from the website for the duration 
-        for which it is valid. The licence file will be read and checked each time the Reverse Generator is run.
+        license to use the licensed Material. Once the license Material has been authorised for use by the 
+        Licensee, a license file will be provided via email to an email address provided by the Licensee. In 
+        addition, the license file will also be made available for download from the website for the duration 
+        for which it is valid. The license file will be read and checked each time the Reverse Generator is run.
 
         5.2.2 Disabled Access 
         LICENSEE ACKNOWLEDGES AND AGREES THAT INSTALLATION OF AND ACCESS TO 
@@ -219,29 +219,29 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     (LIMITATIONS OF LIABILITY) AND THAT THE LIABILITY LIMITATIONS IN THIS SECTION 6 (LIMITATIONS 
     OF LIABILITY) ARE AN ESSENTIAL ELEMENT OF THE AGREEMENT BETWEEN THE PARTIES.
 
-7. Licence Types
+7. license Types
 
-    7.1 Individual commercial licence 
-    If a Licensee is granted an individual licence for the material, then the Licensee may only use the 
-    licence key provided to them and not allow access to or permit the use of such access key to any 
-    other individuals. Licensee may install additional copies of the Licence Materials as needed on 
-    multiple computers or servers provided the Licence Material in its stand-alone form is accessed only 
-    by the Licensee, this does not restrict the Licensee from integrating the Licenced Material into its 
+    7.1 Individual commercial license 
+    If a Licensee is granted an individual license for the material, then the Licensee may only use the 
+    license key provided to them and not allow access to or permit the use of such access key to any 
+    other individuals. Licensee may install additional copies of the license Materials as needed on 
+    multiple computers or servers provided the license Material in its stand-alone form is accessed only 
+    by the Licensee, this does not restrict the Licensee from integrating the licensed Material into its 
     own developed programs and distributing those programs in compliance with section 2.
 
-    7.2 Academic / Non-Commercial Licence
-    If a Licensee is granted an Academic / Non-Commercial Licence for the material, then the Licensee 
-    may only use the licence key provided to them and not allow access to or permit the use of such 
-    access key to any other individuals. Any use of the Licence Material must be used for Academic / 
-    Non-Commercial purposes only. No programs developed utilised under this licence type maybe 
+    7.2 Academic / Non-Commercial license
+    If a Licensee is granted an Academic / Non-Commercial license for the material, then the Licensee 
+    may only use the license key provided to them and not allow access to or permit the use of such 
+    access key to any other individuals. Any use of the license Material must be used for Academic / 
+    Non-Commercial purposes only. No programs developed utilised under this license type maybe 
     distributed for any reason other than Academic / Non-Commercial purposes.
 
     7.3 Evaluation, Demonstration or Trial
-    If a Licensee is granted an "evaluation" "demonstration" "trial" licence for the material then the
-    Licensee may install a single, primary copy of the Licence Materials on one computer or server and
-    allow access to the primary copy of the licence material solely by the Licensee. Licensee may install
-    one copy of the Licenced Material on a single computer or server accessible only by the Licensee. The
-    Licenced Material may be used solely for the Licensee's personal use such as evaluation of the
+    If a Licensee is granted an "evaluation" "demonstration" "trial" license for the material then the
+    Licensee may install a single, primary copy of the license Materials on one computer or server and
+    allow access to the primary copy of the license material solely by the Licensee. Licensee may install
+    one copy of the licensed Material on a single computer or server accessible only by the Licensee. The
+    licensed Material may be used solely for the Licensee's personal use such as evaluation of the
     Licensed Material. This licensed type will be for a fixed term based on the determination of REVERSE
     POCO or if no such term as specified, the term is seven (7) days from installation or as otherwise
     authorised in writing by REVERSE POCO.
@@ -249,11 +249,11 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
 8. Term and Termination
 
     8.1 Term, Termination or Suspension
-    Each licence under this Agreement, with respect to each specific set of Licensed Materials covered 
+    Each license under this Agreement, with respect to each specific set of Licensed Materials covered 
     by this Agreement, will become effective as of the latest to occur of:
         (a) this Agreement becoming effective; or 
-        (b) payment by Licensee of the applicable fees, excluding licences (such as 
-            academic / trial licences) where no fees are required; or
+        (b) payment by Licensee of the applicable fees, excluding licenses (such as 
+            academic / trial licenses) where no fees are required; or
         (c) delivery of the specific Licensed Materials.
 
     8.2
@@ -261,11 +261,11 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     Materials if the other party is in breach of this Agreement and fails to cure such breach within ten 
     (10) days after written notice of the breach.
     However, if the Licensee is in breach of sections 1 or 2 of this Agreement, REVERSE POCO may 
-    terminate this Agreement or Licence of the Licensed Materials immediately upon written notice of 
+    terminate this Agreement or license of the Licensed Materials immediately upon written notice of 
     the breach.
 
     8.3
-    In addition, REVERSE POCO may, as an alternative to termination, suspend the Licensee's licence as 
+    In addition, REVERSE POCO may, as an alternative to termination, suspend the Licensee's license as 
     to the Licensed Materials relating to the Licensed Materials, or any other obligations or Licensee 
     rights under this Agreement (or under other terms, if any, relating to Materials associated with the 
     Licensed Materials), if Licensee fails to make a payment to REVERSE POCO or otherwise fails to 
@@ -282,9 +282,9 @@ WITH YOUR PURCHASE OR USE OF A LICENSE FOR USE OF THE REVERSE POCO MATERIALS.
     rights or obligations under this Agreement.
     
     8.6
-    Upon termination or expiration of this Agreement, the licences granted hereunder will terminate.  
-    Upon termination or expiration of any licence granted to the Licensee, the Licensee must cease all 
-    use of REVERSE POCO's Materials to which such licence applies and Uninstall all copies of the 
+    Upon termination or expiration of this Agreement, the licenses granted hereunder will terminate.  
+    Upon termination or expiration of any license granted to the Licensee, the Licensee must cease all 
+    use of REVERSE POCO's Materials to which such license applies and Uninstall all copies of the 
     REVERSE POCO's Materials.
     At REVERSE POCO's request, the Licensee agrees to destroy or return to REVERSE POCO.
     REVERSE POCO reserves the right to require the Licensee to show satisfactory proof that all copies of 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ It also allows you to customise the generated code to your liking.
 ### Watch a short video clip (no audio)
 [![Watch the video](https://reversepocostorage.blob.core.windows.net/public-file-share/efcore-first-run.jpg)](https://reversepocostorage.blob.core.windows.net/public-file-share/efcore-first-run.mp4)
 
-### To remove trial limitations, you will require a licence key
+### To remove trial limitations, you will require a license key
 Free to academics (you need a .edu or a .ac email address), not free for commercial use.
 
-Go to the [ReversePOCO](https://www.reversepoco.co.uk) website to obtain your licence key.
+Go to the [ReversePOCO](https://www.reversepoco.co.uk) website to obtain your license key.
 
 ### Upgrading v2 to v3
 Please read the [Upgrading documentation](https://github.com/sjh37/EntityFramework-Reverse-POCO-Code-First-Generator/wiki/Upgrading-from-v2-to-v3)

--- a/Tester.Integration.EfCore3/ContextHasSameNameAsDb/Fred.tt
+++ b/Tester.Integration.EfCore3/ContextHasSameNameAsDb/Fred.tt
@@ -96,7 +96,7 @@
     Settings.UsePragma                        = false; // If false, suppresses the writing of #pragma
     Settings.AllowNullStrings                 = false; // If true, will allow string? properties and will add '#nullable enable' to the top of each file
     Settings.UseResharper                     = true;  // If true, will add a list of 'ReSharper disable' comments to the top of each file
-    Settings.ShowLicenseInfo                  = false; // If true, will add the licence info comment to the top of each file
+    Settings.ShowLicenseInfo                  = false; // If true, will add the license info comment to the top of each file
     Settings.IncludeConnectionSettingComments = false; // Add comments describing connection settings used to generate file
     Settings.IncludeCodeGeneratedAttribute    = false; // If true, will include the [GeneratedCode] attribute before classes, false to remove it.
 

--- a/Tester.Integration.EfCore3/Fred.cs
+++ b/Tester.Integration.EfCore3/Fred.cs
@@ -3,8 +3,8 @@
 //
 // Registered to: Simon Hughes
 // Company      : Reverse POCO
-// Licence Type : Commercial
-// Licences     : 1
+// license Type : Commercial
+// licenses     : 1
 // Valid until  : 07 DEC 2021
 //
 // The following connection settings were used to generate this file:

--- a/Tester.Integration.EfCore3/Fred.tt
+++ b/Tester.Integration.EfCore3/Fred.tt
@@ -102,7 +102,7 @@
     Settings.UsePragma                        = false; // If false, suppresses the writing of #pragma
     Settings.AllowNullStrings                 = false; // If true, will allow string? properties and will add '#nullable enable' to the top of each file
     Settings.UseResharper                     = true;  // If true, will add a list of 'ReSharper disable' comments to the top of each file
-    Settings.ShowLicenseInfo                  = true; // If true, will add the licence info comment to the top of each file
+    Settings.ShowLicenseInfo                  = true; // If true, will add the license info comment to the top of each file
     Settings.IncludeConnectionSettingComments = true; // Add comments describing connection settings used to generate file
     Settings.IncludeCodeGeneratedAttribute    = false; // If true, will include the [GeneratedCode] attribute before classes, false to remove it.
 

--- a/Tester.Integration.EfCore5/EnumOnly.tt
+++ b/Tester.Integration.EfCore5/EnumOnly.tt
@@ -105,7 +105,7 @@
     Settings.UsePragma                        = false; // If false, suppresses the writing of #pragma
     Settings.AllowNullStrings                 = false; // If true, will allow string? properties and will add '#nullable enable' to the top of each file
     Settings.UseResharper                     = true;  // If true, will add a list of 'ReSharper disable' comments to the top of each file
-    Settings.ShowLicenseInfo                  = false; // If true, will add the licence info comment to the top of each file
+    Settings.ShowLicenseInfo                  = false; // If true, will add the license info comment to the top of each file
     Settings.IncludeConnectionSettingComments = false; // Add comments describing connection settings used to generate file
     Settings.IncludeCodeGeneratedAttribute    = true; // If true, will include the [GeneratedCode] attribute before classes, false to remove it.
 

--- a/Tester.Integration.EfCore5/Northwind.tt
+++ b/Tester.Integration.EfCore5/Northwind.tt
@@ -105,7 +105,7 @@
     Settings.UsePragma                        = false; // If false, suppresses the writing of #pragma
     Settings.AllowNullStrings                 = false; // If true, will allow string? properties and will add '#nullable enable' to the top of each file
     Settings.UseResharper                     = true;  // If true, will add a list of 'ReSharper disable' comments to the top of each file
-    Settings.ShowLicenseInfo                  = false; // If true, will add the licence info comment to the top of each file
+    Settings.ShowLicenseInfo                  = false; // If true, will add the license info comment to the top of each file
     Settings.IncludeConnectionSettingComments = false; // Add comments describing connection settings used to generate file
     Settings.IncludeCodeGeneratedAttribute    = false; // If true, will include the [GeneratedCode] attribute before classes, false to remove it.
 


### PR DESCRIPTION
a little typo in some files including readme where license was misspelled as licence.