### PR TITLE
Add UsePascalCase setting for Enum members

### DIFF
--- a/BuildTT/BuildTT.cs
+++ b/BuildTT/BuildTT.cs
@@ -365,6 +365,22 @@ namespace BuildTT
         }
     };
 
+    // Use the following function if you need to apply additional modifications to a enum
+    // Called just before UpdateEnumMember
+    Settings.UpdateEnum = delegate (Enumeration enumeration)
+    {
+        //enumeration.EnumAttributes.Add(""[DataContract]"");
+    };
+
+    // Use the following function if you need to apply additional modifications to a enum member
+    Settings.UpdateEnumMember = delegate (EnumerationMember enumerationMember)
+    {
+        //enumerationMember.Attributes.Add(""[EnumMember]"");
+
+        //enumerationMember.Attributes.Add(""[SomeAttribute(\"""" + enumerationMember.AllValues[""SomeName""] + "" \"")]"");
+    };
+
+
     // Writes any boilerplate stuff inside the POCO class body
     Settings.WriteInsideClassBody = delegate(Table t)
     {

--- a/Generator/Enumeration.cs
+++ b/Generator/Enumeration.cs
@@ -5,9 +5,11 @@ namespace Efrpg
     public class Enumeration
     {
         public readonly string EnumName;
-        public readonly List<KeyValuePair<string, string>> Items;
+        public readonly List<EnumerationMember> Items;
 
-        public Enumeration(string enumName, List<KeyValuePair<string, string>> items)
+        public List<string> EnumAttributes = new List<string>();
+
+        public Enumeration(string enumName, List<EnumerationMember> items)
         {
             EnumName = enumName;
             Items    = items;

--- a/Generator/EnumerationMember.cs
+++ b/Generator/EnumerationMember.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace Efrpg
+{
+    public class EnumerationMember
+    {
+        public readonly string Key;
+        public readonly string Value;
+        public readonly Dictionary<string, object> AllValues;
+
+        public List<string> Attributes = new List<string>();
+
+        public EnumerationMember(string key, string value, Dictionary<string, object> allValues)
+        {
+            Key = key;
+            Value = value;
+            AllValues = allValues;
+        }
+    }
+}

--- a/Generator/Filtering/DbContextFilter.cs
+++ b/Generator/Filtering/DbContextFilter.cs
@@ -30,6 +30,8 @@ namespace Efrpg.Filtering
         public abstract string MappingTableRename(string mappingTable, string tableName, string entityName);
         public abstract void UpdateTable(Table table);
         public abstract void UpdateColumn(Column column, Table table);
+        public abstract void UpdateEnum(Enumeration enumeration);
+        public abstract void UpdateEnumMember(EnumerationMember enumerationMember);
         public abstract void ViewProcessing(Table view);
         public abstract string StoredProcedureRename(StoredProcedure sp);
         public abstract string StoredProcedureReturnModelRename(string name, StoredProcedure sp);

--- a/Generator/Filtering/IDbContextFilter.cs
+++ b/Generator/Filtering/IDbContextFilter.cs
@@ -21,6 +21,8 @@ namespace Efrpg.Filtering
         string     MappingTableRename(string mappingTable, string tableName, string entityName);
         void       UpdateTable(Table table);
         void       UpdateColumn(Column column, Table table);
+        void       UpdateEnum(Enumeration enumeration);
+        void       UpdateEnumMember(EnumerationMember enumerationMember);
         void       ViewProcessing(Table view);
         string     StoredProcedureRename(StoredProcedure sp);
         string     StoredProcedureReturnModelRename(string name, StoredProcedure sp);

--- a/Generator/Filtering/MultiContextFilter.cs
+++ b/Generator/Filtering/MultiContextFilter.cs
@@ -346,6 +346,16 @@ namespace Efrpg.Filtering
             Settings.UpdateColumn?.Invoke(column, table, null);
         }
 
+        public override void UpdateEnum(Enumeration enumeration)
+        {
+
+        }
+
+        public override void UpdateEnumMember(EnumerationMember enumerationMember)
+        {
+
+        }
+
         public override void ViewProcessing(Table view)
         {
             // Find the multi-context settings for this view

--- a/Generator/Filtering/SingleContextFilter.cs
+++ b/Generator/Filtering/SingleContextFilter.cs
@@ -94,6 +94,16 @@ namespace Efrpg.Filtering
             Settings.UpdateColumn?.Invoke(column, table, EnumDefinitions);
         }
 
+        public override void UpdateEnum(Enumeration enumeration)
+        {
+            Settings.UpdateEnum?.Invoke(enumeration);
+        }
+
+        public override void UpdateEnumMember(EnumerationMember enumerationMember)
+        {
+            Settings.UpdateEnumMember?.Invoke(enumerationMember);
+        }
+
         public override void ViewProcessing(Table view)
         {
             // Callback to Settings, which can be set within <database>.tt

--- a/Generator/Generator.csproj
+++ b/Generator/Generator.csproj
@@ -61,6 +61,7 @@
   <ItemGroup>
     <Compile Include="AssemblyHelper.cs" />
     <Compile Include="EfrpgVersion.cs" />
+    <Compile Include="EnumerationMember.cs" />
     <Compile Include="FileManagement\VisualStudioFileManager.cs" />
     <Compile Include="FileManagement\CustomFileManager.cs" />
     <Compile Include="FileManagement\EntityFrameworkTemplateFileManager.cs" />

--- a/Generator/Generators/Generator.cs
+++ b/Generator/Generators/Generator.cs
@@ -416,6 +416,15 @@ namespace Efrpg.Generators
 
                     table.Suffix = Settings.TableSuffix;
                 }
+
+                foreach (var enumeration in filter.Enums)
+                {
+                    filter.UpdateEnum(enumeration);
+                    foreach (var enumerationMember in enumeration.Items)
+                    {
+                        filter.UpdateEnumMember(enumerationMember);
+                    }
+                }
             }
         }
 

--- a/Generator/Generators/Generator.cs
+++ b/Generator/Generators/Generator.cs
@@ -199,6 +199,19 @@ namespace Efrpg.Generators
                             filterKeyValuePair.Value.Enums.AddRange(enumerations);
                     }
                 }
+
+                foreach (var filterKeyValuePair in FilterList.GetFilters())
+                {
+                    var filter = filterKeyValuePair.Value;
+                    foreach (var enumeration in filter.Enums)
+                    {
+                        filter.UpdateEnum(enumeration);
+                        foreach (var enumerationMember in enumeration.Items)
+                        {
+                            filter.UpdateEnumMember(enumerationMember);
+                        }
+                    }
+                }
             }
             catch (Exception x)
             {
@@ -415,15 +428,6 @@ namespace Efrpg.Generators
                         filter.UpdateColumn(column, table);
 
                     table.Suffix = Settings.TableSuffix;
-                }
-
-                foreach (var enumeration in filter.Enums)
-                {
-                    filter.UpdateEnum(enumeration);
-                    foreach (var enumerationMember in enumeration.Items)
-                    {
-                        filter.UpdateEnumMember(enumerationMember);
-                    }
                 }
             }
         }

--- a/Generator/Readers/DatabaseReader.cs
+++ b/Generator/Readers/DatabaseReader.cs
@@ -815,7 +815,7 @@ namespace Efrpg.Readers
                                     continue;
 
                                 name = RemoveNonAlphanumerics.Replace(name, string.Empty);
-                                name = Inflector.ToTitleCase(name).Replace(" ", "").Trim();
+                                name = (Settings.UsePascalCaseForEnumMembers ? Inflector.ToTitleCase(name) : name).Replace(" ", string.Empty).Trim();
                                 if (string.IsNullOrEmpty(name))
                                     continue;
 

--- a/Generator/Readers/DatabaseReader.cs
+++ b/Generator/Readers/DatabaseReader.cs
@@ -807,7 +807,8 @@ namespace Efrpg.Readers
                     {
                         using (var rdr = cmd.ExecuteReader())
                         {
-                            var items = new List<KeyValuePair<string, string>>();
+                            var items = new List<EnumerationMember>();
+
                             while (rdr.Read())
                             {
                                 var name = rdr["NameField"].ToString().Trim();
@@ -823,11 +824,20 @@ namespace Efrpg.Readers
                                 if (string.IsNullOrEmpty(value))
                                     continue;
 
-                                items.Add(new KeyValuePair<string, string>(name, value));
+                                var allValues = new Dictionary<string, object>();
+                                for (var n = 2; n < rdr.FieldCount; ++n)
+                                {
+                                    var o = rdr.GetValue(n);
+                                    allValues.Add(rdr.GetName(n), o != DBNull.Value ? o : null);
+                                }
+
+                                items.Add(new EnumerationMember(name, value, allValues));
                             }
 
                             if(items.Any())
+                            {
                                 result.Add(new Enumeration(e.Name, items));
+                            }
                         }
                     }
                     catch (Exception)

--- a/Generator/Readers/PostgreSqlDatabaseReader.cs
+++ b/Generator/Readers/PostgreSqlDatabaseReader.cs
@@ -193,7 +193,7 @@ ORDER BY R.specific_schema, R.routine_name, R.routine_type;";
 
         protected override string EnumSQL(string table, string nameField, string valueField)
         {
-            return string.Format(@"SELECT ""{0}"" as ""NameField"", ""{1}"" as ""ValueField"" FROM ""{2}"";", nameField, valueField, table);
+            return string.Format(@"SELECT ""{0}"" as ""NameField"", ""{1}"" as ""ValueField"", * FROM ""{2}"";", nameField, valueField, table);
         }
 
         protected override string SequenceSQL()

--- a/Generator/Readers/SqlServerCeDatabaseReader.cs
+++ b/Generator/Readers/SqlServerCeDatabaseReader.cs
@@ -179,7 +179,7 @@ SELECT * FROM MultiContext.ForeignKey;";
 
         protected override string EnumSQL(string table, string nameField, string valueField)
         {
-            return string.Format("SELECT {0} as NameField, {1} as ValueField FROM {2};", nameField, valueField, table);
+            return string.Format("SELECT {0} as NameField, {1} as ValueField, * FROM {2};", nameField, valueField, table);
         }
 
         protected override string SequenceSQL()

--- a/Generator/Readers/SqlServerDatabaseReader.cs
+++ b/Generator/Readers/SqlServerDatabaseReader.cs
@@ -458,7 +458,7 @@ SELECT * FROM MultiContext.ForeignKey;";
 
         protected override string EnumSQL(string table, string nameField, string valueField)
         {
-            return string.Format("SELECT {0} as NameField, {1} as ValueField FROM {2};", nameField, valueField, table);
+            return string.Format("SELECT {0} as NameField, {1} as ValueField, * FROM {2};", nameField, valueField, table);
         }
 
         protected override string SequenceSQL()

--- a/Generator/Settings.cs
+++ b/Generator/Settings.cs
@@ -46,6 +46,7 @@ namespace Efrpg
         public static string ResultClassModifiers          = "public"; // "public partial";
 
         public static bool UsePascalCase                            = true; // This will rename the generated C# tables & properties to use PascalCase. If false table & property names will be left alone.
+        public static bool UsePascalCaseForEnumMembers              = true; // This will rename the generated Enum Members to use PascalCase. If false Enum members will be left alone.
         public static bool UseDataAnnotations                       = false; // If true, will add data annotations to the poco classes.
         public static bool UsePropertyInitialisers                  = false; // Removes POCO constructor and instead uses C# 6 property initialisers to set defaults
         public static bool UseLazyLoading                           = true; // Marks all navigation properties as virtual or not, to support or disable EF Lazy Loading feature

--- a/Generator/Settings.cs
+++ b/Generator/Settings.cs
@@ -268,14 +268,19 @@ namespace Efrpg
             }
         };
 
+        // Use the following function if you need to apply additional modifications to a enum
+        // Called just before UpdateEnumMember
         public static Action<Enumeration> UpdateEnum = delegate (Enumeration enumeration)
         {
-
+            //enumeration.EnumAttributes.Add("[DataContract]");
         };
 
+        // Use the following function if you need to apply additional modifications to a enum member
         public static Action<EnumerationMember> UpdateEnumMember = delegate (EnumerationMember enumerationMember)
         {
+            //enumerationMember.Attributes.Add("[EnumMember]");
 
+            //enumerationMember.Attributes.Add("[SomeAttribute(\"" + enumerationMember.AllValues["SomeName"] + " \")]");
         };
 
         // Writes any boilerplate stuff inside the POCO class body

--- a/Generator/Settings.cs
+++ b/Generator/Settings.cs
@@ -268,6 +268,16 @@ namespace Efrpg
             }
         };
 
+        public static Action<Enumeration> UpdateEnum = delegate (Enumeration enumeration)
+        {
+
+        };
+
+        public static Action<EnumerationMember> UpdateEnumMember = delegate (EnumerationMember enumerationMember)
+        {
+
+        };
+
         // Writes any boilerplate stuff inside the POCO class body
         public static Func<Table, string> WriteInsideClassBody = delegate (Table t)
         {

--- a/Generator/Templates/TemplateEf6.cs
+++ b/Generator/Templates/TemplateEf6.cs
@@ -1287,9 +1287,13 @@ using {{this}};{{#newline}}
         public override string Enums()
         {
             return @"
+{{EnumAttributes}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}
+    {{#each Attributes}}
+        {{this}}{{#newline}}
+    {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}
 }{{#newline}}

--- a/Generator/Templates/TemplateEf6.cs
+++ b/Generator/Templates/TemplateEf6.cs
@@ -1287,7 +1287,9 @@ using {{this}};{{#newline}}
         public override string Enums()
         {
             return @"
-{{EnumAttributes}}
+{{#each EnumAttributes}}
+    {{this}}{{#newline}}
+{{/each}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}

--- a/Generator/Templates/TemplateEf6.cs
+++ b/Generator/Templates/TemplateEf6.cs
@@ -1288,13 +1288,13 @@ using {{this}};{{#newline}}
         {
             return @"
 {{#each EnumAttributes}}
-    {{this}}{{#newline}}
+{{this}}{{#newline}}
 {{/each}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}
     {{#each Attributes}}
-        {{this}}{{#newline}}
+    {{this}}{{#newline}}
     {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}

--- a/Generator/Templates/TemplateEfCore2.cs
+++ b/Generator/Templates/TemplateEfCore2.cs
@@ -1349,13 +1349,13 @@ using {{this}};{{#newline}}
         {
             return @"
 {{#each EnumAttributes}}
-    {{this}}{{#newline}}
+{{this}}{{#newline}}
 {{/each}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}
     {{#each Attributes}}
-        {{this}}{{#newline}}
+    {{this}}{{#newline}}
     {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}

--- a/Generator/Templates/TemplateEfCore2.cs
+++ b/Generator/Templates/TemplateEfCore2.cs
@@ -1348,7 +1348,9 @@ using {{this}};{{#newline}}
         public override string Enums()
         {
             return @"
-{{EnumAttributes}}
+{{#each EnumAttributes}}
+    {{this}}{{#newline}}
+{{/each}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}

--- a/Generator/Templates/TemplateEfCore2.cs
+++ b/Generator/Templates/TemplateEfCore2.cs
@@ -1348,9 +1348,13 @@ using {{this}};{{#newline}}
         public override string Enums()
         {
             return @"
+{{EnumAttributes}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}
+    {{#each Attributes}}
+        {{this}}{{#newline}}
+    {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}
 }{{#newline}}

--- a/Generator/Templates/TemplateEfCore3.cs
+++ b/Generator/Templates/TemplateEfCore3.cs
@@ -1468,9 +1468,13 @@ using {{this}};{{#newline}}
         public override string Enums()
         {
             return @"
+{{EnumAttributes}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}
+    {{#each Attributes}}
+        {{this}}{{#newline}}
+    {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}
 }{{#newline}}

--- a/Generator/Templates/TemplateEfCore3.cs
+++ b/Generator/Templates/TemplateEfCore3.cs
@@ -1468,7 +1468,9 @@ using {{this}};{{#newline}}
         public override string Enums()
         {
             return @"
-{{EnumAttributes}}
+{{#each EnumAttributes}}
+    {{this}}{{#newline}}
+{{/each}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}

--- a/Generator/Templates/TemplateEfCore3.cs
+++ b/Generator/Templates/TemplateEfCore3.cs
@@ -1469,13 +1469,13 @@ using {{this}};{{#newline}}
         {
             return @"
 {{#each EnumAttributes}}
-    {{this}}{{#newline}}
+{{this}}{{#newline}}
 {{/each}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}
     {{#each Attributes}}
-        {{this}}{{#newline}}
+    {{this}}{{#newline}}
     {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}

--- a/Generator/Templates/TemplateEfCore5.cs
+++ b/Generator/Templates/TemplateEfCore5.cs
@@ -1446,13 +1446,13 @@ using {{this}};{{#newline}}
         {
             return @"
 {{#each EnumAttributes}}
-    {{this}}{{#newline}}
+{{this}}{{#newline}}
 {{/each}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}
     {{#each Attributes}}
-        {{this}}{{#newline}}
+    {{this}}{{#newline}}
     {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}

--- a/Generator/Templates/TemplateEfCore5.cs
+++ b/Generator/Templates/TemplateEfCore5.cs
@@ -1445,9 +1445,13 @@ using {{this}};{{#newline}}
         public override string Enums()
         {
             return @"
+{{EnumAttributes}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}
+    {{#each Attributes}}
+        {{this}}{{#newline}}
+    {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}
 }{{#newline}}

--- a/Generator/Templates/TemplateEfCore5.cs
+++ b/Generator/Templates/TemplateEfCore5.cs
@@ -1445,7 +1445,9 @@ using {{this}};{{#newline}}
         public override string Enums()
         {
             return @"
-{{EnumAttributes}}
+{{#each EnumAttributes}}
+    {{this}}{{#newline}}
+{{/each}}
 public enum {{EnumName}}{{#newline}}
 {{{#newline}}
 {{#each Items}}

--- a/Tester.Integration.EfCore3/File based templates/Templates.EF6/Enums.mustache
+++ b/Tester.Integration.EfCore3/File based templates/Templates.EF6/Enums.mustache
@@ -1,6 +1,13 @@
-﻿public enum {{EnumName}}{{#newline}}
-{{{#newline}}
+﻿{{#each EnumAttributes}}
+{{this}}{{#newline}}
+{{/each}}
+public enum {{EnumName}}{{#newline}}
+{{{
+#newline}}
 {{#each Items}}
+    {{#each Attributes}}
+        {{this}}{{#newline}}
+    {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}
 }{{#newline}}

--- a/Tester.Integration.EfCore3/File based templates/Templates.EF6/Enums.mustache
+++ b/Tester.Integration.EfCore3/File based templates/Templates.EF6/Enums.mustache
@@ -6,7 +6,7 @@ public enum {{EnumName}}{{#newline}}
 #newline}}
 {{#each Items}}
     {{#each Attributes}}
-        {{this}}{{#newline}}
+    {{this}}{{#newline}}
     {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}

--- a/Tester.Integration.EfCore3/File based templates/Templates.EFCore3/Enums.mustache
+++ b/Tester.Integration.EfCore3/File based templates/Templates.EFCore3/Enums.mustache
@@ -1,6 +1,13 @@
-﻿public enum {{EnumName}}{{#newline}}
-{{{#newline}}
+﻿{{#each EnumAttributes}}
+{{this}}{{#newline}}
+{{/each}}
+public enum {{EnumName}}{{#newline}}
+{{{
+#newline}}
 {{#each Items}}
+    {{#each Attributes}}
+        {{this}}{{#newline}}
+    {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}
 }{{#newline}}

--- a/Tester.Integration.EfCore3/File based templates/Templates.EFCore3/Enums.mustache
+++ b/Tester.Integration.EfCore3/File based templates/Templates.EFCore3/Enums.mustache
@@ -6,7 +6,7 @@ public enum {{EnumName}}{{#newline}}
 #newline}}
 {{#each Items}}
     {{#each Attributes}}
-        {{this}}{{#newline}}
+    {{this}}{{#newline}}
     {{/each}}
     {{Key}} = {{Value}},{{#newline}}
 {{/each}}


### PR DESCRIPTION
For now not possible to Generate enum members as is in the Database, but it is useful setting because not always enum should be translated to Pascal case. 
Use **Setting.PascalCase** for this behavior is also not good, because it should be independent settings. 