### PR TITLE
multi-target tests

### DIFF
--- a/Generator.Tests.Unit.EFCore/Generator.Tests.Unit.EFCore.csproj
+++ b/Generator.Tests.Unit.EFCore/Generator.Tests.Unit.EFCore.csproj
@@ -1,18 +1,39 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.16" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="dotMorten.Microsoft.SqlServer.Types" Version="1.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework)=='netcoreapp3.1'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.21" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="3.1.21" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.21" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.21" />
+    </ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework)=='NET5.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.12" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="5.0.12" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework)=='NET6.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
+    </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\EntityFramework.Reverse.POCO.Generator\EntityFramework.Reverse.POCO.Generator.csproj" />

--- a/Tester.Integration.EfCore3/Tester.Integration.EfCore3.csproj
+++ b/Tester.Integration.EfCore3/Tester.Integration.EfCore3.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <UserSecretsId>e270ff78-4a96-4910-ac6e-8a2181e05f08</UserSecretsId>
     </PropertyGroup>
-
-    <ItemGroup>
-        <None Remove="appsettings.json" />
-        <None Remove="TestDatabase.sql" />
-    </ItemGroup>
 
     <ItemGroup>
         <Content Include="appsettings.json">
@@ -15,15 +11,33 @@
         </Content>
         <Content Include="TestDatabase.sql" />
     </ItemGroup>
-
     <ItemGroup>
         <PackageReference Include="dotMorten.Microsoft.SqlServer.Types" Version="1.3.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.16" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="3.1.16" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.16" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
         <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    </ItemGroup>
+
+
+    <ItemGroup Condition="$(TargetFramework)=='netcoreapp3.1'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.21" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="3.1.21" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.21" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.21" />
+    </ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework)=='NET5.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.12" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="5.0.12" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework)=='NET6.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -92,9 +106,9 @@
             <DependentUpon>MCFBT.tt</DependentUpon>
         </Compile>
         <Compile Update="File based templates\SCFBT.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>SCFBT.tt</DependentUpon>
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>SCFBT.tt</DependentUpon>
         </Compile>
         <Compile Update="Fred.cs">
           <DesignTime>True</DesignTime>
@@ -122,9 +136,9 @@
             <DependentUpon>TestDatabase.tt</DependentUpon>
         </Compile>
         <Compile Update="TestSynonymsDatabase.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>TestSynonymsDatabase.tt</DependentUpon>
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>TestSynonymsDatabase.tt</DependentUpon>
         </Compile>
     </ItemGroup>
 


### PR DESCRIPTION
Hi Simon (@sjh37)
Here is an example of using multi-targeting.  This could also help reduce the number of **Test.Integration.xxx**  and maybe use one for **netcoreapp3.1;net5.0;net6.0**  and one for **net461;net462;net471;net472;net48** (and one for **netcoreapp2.1**;**netcoreapp2.2** if you want to continue to support that) 
As you test it out you will find a couple of bugs with .NET 6
fix #729

NOTE:  you'll need Visual Studio 2022 to compile **net6.0**