### PR TITLE
Enable commandtimeout override

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
@@ -17899,6 +17899,7 @@ using {{this}};{{#newline}}
 {{#else}}
         var procResultData = new {{WriteStoredProcReturnModelName}}();{{#newline}}
         var cmd = Database.Connection.CreateCommand();{{#newline}}
+        cmd.CommandTimeout = Database.CommandTimeout ?? cmd.CommandTimeout;{{#newline}}
         cmd.CommandType = CommandType.StoredProcedure;{{#newline}}
         cmd.CommandText = ""{{Exec}}"";{{#newline}}
 {{#each Parameters}}
@@ -17949,6 +17950,7 @@ using {{this}};{{#newline}}
 {{#else}}
         var procResultData = new {{WriteStoredProcReturnModelName}}();{{#newline}}
         var cmd = Database.Connection.CreateCommand();{{#newline}}
+        cmd.CommandTimeout = Database.CommandTimeout ?? cmd.CommandTimeout;{{#newline}}
         cmd.CommandType = CommandType.StoredProcedure;{{#newline}}
         cmd.CommandText = ""{{Exec}}"";{{#newline}}
 {{#each Parameters}}

--- a/Generator/Templates/TemplateEf6.cs
+++ b/Generator/Templates/TemplateEf6.cs
@@ -371,6 +371,7 @@ using {{this}};{{#newline}}
 {{#else}}
         var procResultData = new {{WriteStoredProcReturnModelName}}();{{#newline}}
         var cmd = Database.Connection.CreateCommand();{{#newline}}
+        cmd.CommandTimeout = Database.CommandTimeout ?? cmd.CommandTimeout;{{#newline}}
         cmd.CommandType = CommandType.StoredProcedure;{{#newline}}
         cmd.CommandText = ""{{Exec}}"";{{#newline}}
 {{#each Parameters}}
@@ -421,6 +422,7 @@ using {{this}};{{#newline}}
 {{#else}}
         var procResultData = new {{WriteStoredProcReturnModelName}}();{{#newline}}
         var cmd = Database.Connection.CreateCommand();{{#newline}}
+        cmd.CommandTimeout = Database.CommandTimeout ?? cmd.CommandTimeout;{{#newline}}
         cmd.CommandType = CommandType.StoredProcedure;{{#newline}}
         cmd.CommandText = ""{{Exec}}"";{{#newline}}
 {{#each Parameters}}

--- a/_File based templates/Templates.EF6/DatabaseContext.mustache
+++ b/_File based templates/Templates.EF6/DatabaseContext.mustache
@@ -180,6 +180,7 @@
 {{#else}}
         var procResultData = new {{WriteStoredProcReturnModelName}}();{{#newline}}
         var cmd = Database.Connection.CreateCommand();{{#newline}}
+        cmd.CommandTimeout = Database.CommandTimeout ?? cmd.CommandTimeout;{{#newline}}
         cmd.CommandType = CommandType.StoredProcedure;{{#newline}}
         cmd.CommandText = "{{Exec}}";{{#newline}}
 {{#each Parameters}}
@@ -230,6 +231,7 @@
 {{#else}}
         var procResultData = new {{WriteStoredProcReturnModelName}}();{{#newline}}
         var cmd = Database.Connection.CreateCommand();{{#newline}}
+        cmd.CommandTimeout = Database.CommandTimeout ?? cmd.CommandTimeout;{{#newline}}
         cmd.CommandType = CommandType.StoredProcedure;{{#newline}}
         cmd.CommandText = "{{Exec}}";{{#newline}}
 {{#each Parameters}}


### PR DESCRIPTION
With this adjustment, it is possible to override the default commandtimeout at runtime which can be necessary for specific stored procedures.

_context.Database.CommandTimeout = 300;
return _context.spMyHeavyStoredProcedure.FirstOrDefault();

