### PR TITLE
Intercept stored procedure return model creation

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.v3.ttinclude
@@ -235,6 +235,21 @@
         //StoredProcedureReturnTypes.Add("SalesByYear", "SummaryOfSalesByYear");
         public static Dictionary<string, string> StoredProcedureReturnTypes = new Dictionary<string, string>();
 
+        /// <summary>
+        /// Enable intercept stored procedure return model when a exception occurs. Typically when the stored procedure contains temp tables. 
+        /// This allows you render the proper error in comment or fix the return model by manually creating the returnmodel using a list of DataColumns
+        /// </summary>
+        public static Action<Exception, StoredProcedure> ReadStoredProcReturnObjectException = (exception, proc) => {
+
+        };
+
+        /// <summary>
+        /// Enable intercept stored procedure return model
+        /// </summary>
+        public static Action<StoredProcedure> ReadStoredProcReturnObjectCompleted = (proc) => {
+
+        };
+
 
         // Renaming ***********************************************************************************************************************
         // Table renaming (single context generation only) ************************************************************************************
@@ -16435,10 +16450,12 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 {
                     proc.ReturnModels.Add(ds.Tables[count].Columns.Cast<DataColumn>().ToList());
                 }
+                Settings.ReadStoredProcReturnObjectCompleted(proc);
             }
-            catch (Exception)
+            catch (Exception exception)
             {
                 // Stored procedure does not have a return type
+                Settings.ReadStoredProcReturnObjectException(exception, proc);
             }
         }
 

--- a/Generator/Readers/SqlServerDatabaseReader.cs
+++ b/Generator/Readers/SqlServerDatabaseReader.cs
@@ -1189,10 +1189,12 @@ SELECT  SERVERPROPERTY('Edition') AS Edition,
                 {
                     proc.ReturnModels.Add(ds.Tables[count].Columns.Cast<DataColumn>().ToList());
                 }
+                Settings.ReadStoredProcReturnObjectCompleted(proc);
             }
-            catch (Exception)
+            catch (Exception exception)
             {
                 // Stored procedure does not have a return type
+                Settings.ReadStoredProcReturnObjectException(exception, proc);
             }
         }
 

--- a/Generator/Settings.cs
+++ b/Generator/Settings.cs
@@ -208,6 +208,21 @@ namespace Efrpg
         //StoredProcedureReturnTypes.Add("SalesByYear", "SummaryOfSalesByYear");
         public static Dictionary<string, string> StoredProcedureReturnTypes = new Dictionary<string, string>();
 
+        /// <summary>
+        /// Enable intercept stored procedure return model when a exception occurs. Typically when the stored procedure contains temp tables. 
+        /// This allows you render the proper error in comment or fix the return model by manually creating the returnmodel using a list of DataColumns
+        /// </summary>
+        public static Action<Exception, StoredProcedure> ReadStoredProcReturnObjectException = (exception, proc) => {
+
+        };
+
+        /// <summary>
+        /// Enable intercept stored procedure return model
+        /// </summary>
+        public static Action<StoredProcedure> ReadStoredProcReturnObjectCompleted = (proc) => {
+
+        };
+
 
         // Renaming ***********************************************************************************************************************
         // Table renaming (single context generation only) ************************************************************************************


### PR DESCRIPTION
Enables to have more control regarding return model creation, especially when an error occurs during rendering. 
```cs
Settings.ReadStoredProcReturnObjectException = (ex1, proc) => {
    if (ex1.Message.StartsWith("Invalid object name '#"))
    {
        proc.ReturnModels.Add(new List<DataColumn>(){new DataColumn("ReplaceTemptables")});
    }
}
```
This way you get notified and be able to adjust the sp or to build returnmodel yourself.


There is also ReadStoredProcReturnObjectCompleted method which can be used to create/override more complex resultsets. Which is more practical to use in some cases then the already existing Settings.StoredProcedureReturnTypes.